### PR TITLE
Feature/issue#16: 모임 목록 조회 기능 구현

### DIFF
--- a/src/main/java/kappzzang/jeongsan/Application.java
+++ b/src/main/java/kappzzang/jeongsan/Application.java
@@ -8,8 +8,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @EnableJpaAuditing
 public class Application {
 
-	public static void main(String[] args) {
-		SpringApplication.run(Application.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
 
 }

--- a/src/main/java/kappzzang/jeongsan/controller/TeamController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/TeamController.java
@@ -20,7 +20,7 @@ public class TeamController {
 
     @GetMapping
     public ResponseEntity<List<TeamResponse>> getTeams(@RequestParam("isClosed") Boolean isClosed) {
-        var data = teamService.getTeamsByIsClosed(isClosed);
+        List<TeamResponse> data = teamService.getTeamsByIsClosed(isClosed);
 
         return ResponseEntity.ok(data);
     }

--- a/src/main/java/kappzzang/jeongsan/controller/TeamController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/TeamController.java
@@ -1,0 +1,27 @@
+package kappzzang.jeongsan.controller;
+
+import kappzzang.jeongsan.dto.response.TeamResponse;
+import kappzzang.jeongsan.service.TeamService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController("/api/teams")
+public class TeamController {
+
+    private final TeamService teamService;
+
+    public TeamController(TeamService teamService) {
+        this.teamService = teamService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TeamResponse>> getTeams(@RequestParam("isClosed") Boolean isClosed) {
+        var data = teamService.getTeamsByIsClosed(isClosed);
+
+        return ResponseEntity.ok(data);
+    }
+}

--- a/src/main/java/kappzzang/jeongsan/dto/MemberPreview.java
+++ b/src/main/java/kappzzang/jeongsan/dto/MemberPreview.java
@@ -2,13 +2,13 @@ package kappzzang.jeongsan.dto;
 
 import kappzzang.jeongsan.domain.Member;
 
-public record memberPreview(
+public record MemberPreview(
         String name,
         String profileImage
 ) {
 
-    public static memberPreview from(Member member) {
-        return new memberPreview(
+    public static MemberPreview from(Member member) {
+        return new MemberPreview(
                 member.getNickname(),
                 member.getProfileImage()
         );

--- a/src/main/java/kappzzang/jeongsan/dto/memberPreview.java
+++ b/src/main/java/kappzzang/jeongsan/dto/memberPreview.java
@@ -1,0 +1,16 @@
+package kappzzang.jeongsan.dto;
+
+import kappzzang.jeongsan.domain.Member;
+
+public record memberPreview(
+        String name,
+        String profileImage
+) {
+
+    public static memberPreview from(Member member) {
+        return new memberPreview(
+                member.getNickname(),
+                member.getProfileImage()
+        );
+    }
+}

--- a/src/main/java/kappzzang/jeongsan/dto/response/TeamResponse.java
+++ b/src/main/java/kappzzang/jeongsan/dto/response/TeamResponse.java
@@ -24,6 +24,6 @@ public record TeamResponse(
                         .limit(3)
                         .map(teamMember -> MemberPreview.from(teamMember.getMember()))
                         .toList()
-                );
+        );
     }
 }

--- a/src/main/java/kappzzang/jeongsan/dto/response/TeamResponse.java
+++ b/src/main/java/kappzzang/jeongsan/dto/response/TeamResponse.java
@@ -21,6 +21,7 @@ public record TeamResponse(
                 team.getSubject(),
                 team.getTeamMemberList()
                         .stream()
+                        .limit(3)
                         .map(teamMember -> memberPreview.from(teamMember.getMember()))
                         .toList()
                 );

--- a/src/main/java/kappzzang/jeongsan/dto/response/TeamResponse.java
+++ b/src/main/java/kappzzang/jeongsan/dto/response/TeamResponse.java
@@ -12,6 +12,7 @@ public record TeamResponse(
         String subject,
         List<MemberPreview> memberPreviews
 ) {
+    private static final int MAX_PREVIEW_MEMBERS = 3;
 
     public static TeamResponse from(Team team) {
         return new TeamResponse(
@@ -21,7 +22,7 @@ public record TeamResponse(
                 team.getSubject(),
                 team.getTeamMemberList()
                         .stream()
-                        .limit(3)
+                        .limit(MAX_PREVIEW_MEMBERS)
                         .map(teamMember -> MemberPreview.from(teamMember.getMember()))
                         .toList()
         );

--- a/src/main/java/kappzzang/jeongsan/dto/response/TeamResponse.java
+++ b/src/main/java/kappzzang/jeongsan/dto/response/TeamResponse.java
@@ -1,0 +1,28 @@
+package kappzzang.jeongsan.dto.response;
+
+import kappzzang.jeongsan.domain.Team;
+import kappzzang.jeongsan.dto.memberPreview;
+
+import java.util.List;
+
+public record TeamResponse(
+        Long teamId,
+        String name,
+        Boolean isCompleted,
+        String subject,
+        List<memberPreview> memberPreviews
+) {
+
+    public static TeamResponse from(Team team) {
+        return new TeamResponse(
+                team.getId(),
+                team.getName(),
+                team.getIsClosed(),
+                team.getSubject(),
+                team.getTeamMemberList()
+                        .stream()
+                        .map(teamMember -> memberPreview.from(teamMember.getMember()))
+                        .toList()
+                );
+    }
+}

--- a/src/main/java/kappzzang/jeongsan/dto/response/TeamResponse.java
+++ b/src/main/java/kappzzang/jeongsan/dto/response/TeamResponse.java
@@ -1,7 +1,7 @@
 package kappzzang.jeongsan.dto.response;
 
 import kappzzang.jeongsan.domain.Team;
-import kappzzang.jeongsan.dto.memberPreview;
+import kappzzang.jeongsan.dto.MemberPreview;
 
 import java.util.List;
 
@@ -10,7 +10,7 @@ public record TeamResponse(
         String name,
         Boolean isCompleted,
         String subject,
-        List<memberPreview> memberPreviews
+        List<MemberPreview> memberPreviews
 ) {
 
     public static TeamResponse from(Team team) {
@@ -22,7 +22,7 @@ public record TeamResponse(
                 team.getTeamMemberList()
                         .stream()
                         .limit(3)
-                        .map(teamMember -> memberPreview.from(teamMember.getMember()))
+                        .map(teamMember -> MemberPreview.from(teamMember.getMember()))
                         .toList()
                 );
     }

--- a/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
@@ -2,11 +2,15 @@ package kappzzang.jeongsan.repository;
 
 import kappzzang.jeongsan.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
 
+    @Query("SELECT t FROM Team t " +
+            "JOIN FETCH t.teamMemberList tm " +
+            "JOIN FETCH tm.member " +
+            "WHERE t.isClosed = :isClosed")
     List<Team> findByIsClosed(Boolean isClosed);
-
 }

--- a/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
@@ -1,0 +1,12 @@
+package kappzzang.jeongsan.repository;
+
+import kappzzang.jeongsan.domain.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+
+    List<Team> findByIsClosed(Boolean isClosed);
+
+}

--- a/src/main/java/kappzzang/jeongsan/service/TeamService.java
+++ b/src/main/java/kappzzang/jeongsan/service/TeamService.java
@@ -1,0 +1,24 @@
+package kappzzang.jeongsan.service;
+
+import kappzzang.jeongsan.dto.response.TeamResponse;
+import kappzzang.jeongsan.repository.TeamRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class TeamService {
+
+    private final TeamRepository teamRepository;
+
+    public TeamService(TeamRepository teamRepository) {
+        this.teamRepository = teamRepository;
+    }
+
+    public List<TeamResponse> getTeamsByIsClosed(Boolean isClosed) {
+        return teamRepository.findByIsClosed(isClosed)
+                .stream()
+                .map(TeamResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/kappzzang/jeongsan/service/TeamService.java
+++ b/src/main/java/kappzzang/jeongsan/service/TeamService.java
@@ -3,6 +3,7 @@ package kappzzang.jeongsan.service;
 import kappzzang.jeongsan.dto.response.TeamResponse;
 import kappzzang.jeongsan.repository.TeamRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -15,6 +16,7 @@ public class TeamService {
         this.teamRepository = teamRepository;
     }
 
+    @Transactional(readOnly = true)
     public List<TeamResponse> getTeamsByIsClosed(Boolean isClosed) {
         return teamRepository.findByIsClosed(isClosed)
                 .stream()

--- a/src/main/java/kappzzang/jeongsan/service/TeamService.java
+++ b/src/main/java/kappzzang/jeongsan/service/TeamService.java
@@ -2,19 +2,17 @@ package kappzzang.jeongsan.service;
 
 import kappzzang.jeongsan.dto.response.TeamResponse;
 import kappzzang.jeongsan.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class TeamService {
 
     private final TeamRepository teamRepository;
-
-    public TeamService(TeamRepository teamRepository) {
-        this.teamRepository = teamRepository;
-    }
 
     @Transactional(readOnly = true)
     public List<TeamResponse> getTeamsByIsClosed(Boolean isClosed) {


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 모임 목록 조회 기능을 구현하였습니다.
- 해당 부분 구현을 위해 `MemberPreview`, `TeamResponse`를 record로 정의했습니다.
- `stream`을 적극 활용해 코드를 최대한 간결하게 작성했습니다.


### 🔍 참고 사항
- #14 JeongsanApiResponse 및 enum이 없는 상태에서 data 형식만 정의하여 구현한 상태입니다.
- merge되면 그 때 다시 수정을 할 예정이므로 로직만 확인해주세요.
- 서비스 로직 상 현재 이용하고 있는 **사용자의** 모임 목록을 가져와야 되지만, 이 부분은 추후 member 도메인의 기능이 어느정도 완성됐을 때, annotation을 정의해 활용하거나 jwt token 정보를 이용해 구현하면 좋을 것 같습니다.

### 🐞현재 버그
- `build.gradle`에 `annotationProcessor 'org.projectlombok:lombok'`이 브랜치 버전 차이 문제로 반영되어 있지 않아 실행이 온전히 되지 않습니다.
- 해당 부분은 #19 에 반영되어 있으므로 수정하지 않았습니다.

### #️⃣ 연관 이슈(Git Close)
- #16
- #14
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)