### PR TITLE
Feature/issue#23: 모임 종료 기능 구현 및 모임 관련 기능 반환형 수정

### DIFF
--- a/src/main/java/kappzzang/jeongsan/controller/TeamController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/TeamController.java
@@ -1,6 +1,8 @@
 package kappzzang.jeongsan.controller;
 
 import kappzzang.jeongsan.dto.response.TeamResponse;
+import kappzzang.jeongsan.global.common.JeongsanApiResponse;
+import kappzzang.jeongsan.global.common.enumeration.SuccessType;
 import kappzzang.jeongsan.service.TeamService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,9 +21,9 @@ public class TeamController {
     }
 
     @GetMapping
-    public ResponseEntity<List<TeamResponse>> getTeams(@RequestParam("isClosed") Boolean isClosed) {
+    public ResponseEntity<JeongsanApiResponse<List<TeamResponse>>> getTeams(@RequestParam("isClosed") Boolean isClosed) {
         List<TeamResponse> data = teamService.getTeamsByIsClosed(isClosed);
 
-        return ResponseEntity.ok(data);
+        return JeongsanApiResponse.success(SuccessType.TEAM_LIST_LOADED, data);
     }
 }

--- a/src/main/java/kappzzang/jeongsan/controller/TeamController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/TeamController.java
@@ -1,13 +1,13 @@
 package kappzzang.jeongsan.controller;
 
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import kappzzang.jeongsan.dto.request.CloseTeamRequest;
 import kappzzang.jeongsan.dto.response.TeamResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
 import kappzzang.jeongsan.global.common.enumeration.SuccessType;
 import kappzzang.jeongsan.service.TeamService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -25,5 +25,12 @@ public class TeamController {
         List<TeamResponse> data = teamService.getTeamsByIsClosed(isClosed);
 
         return JeongsanApiResponse.success(SuccessType.TEAM_LIST_LOADED, data);
+    }
+
+    @PatchMapping("/{teamId}")
+    public ResponseEntity<JeongsanApiResponse<Void>> closeTeam(
+        @PathVariable("teamId") Long teamId, @RequestBody CloseTeamRequest request) {
+        teamService.closeTeam(teamId, request);
+        return JeongsanApiResponse.success(SuccessType.TEAM_CLOSED);
     }
 }

--- a/src/main/java/kappzzang/jeongsan/domain/Team.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Team.java
@@ -1,6 +1,8 @@
 package kappzzang.jeongsan.domain;
 
 import jakarta.persistence.*;
+import kappzzang.jeongsan.global.common.enumeration.ErrorType;
+import kappzzang.jeongsan.global.exception.JeongsanException;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,8 +26,10 @@ public class Team extends BaseEntity {
     private List<TeamMember> teamMemberList;
 
     public void closeTeam(Boolean isClosed) {
-        if (isClosed) {
-            this.isClosed = true;
+        if (this.isClosed) {
+            throw new JeongsanException(ErrorType.TEAM_ALREADY_CLOSED);
         }
+
+        this.isClosed = isClosed;
     }
 }

--- a/src/main/java/kappzzang/jeongsan/domain/Team.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Team.java
@@ -22,4 +22,10 @@ public class Team extends BaseEntity {
 
     @OneToMany(mappedBy = "team")
     private List<TeamMember> teamMemberList;
+
+    public void closeTeam(Boolean isClosed) {
+        if (isClosed) {
+            this.isClosed = true;
+        }
+    }
 }

--- a/src/main/java/kappzzang/jeongsan/dto/request/CloseTeamRequest.java
+++ b/src/main/java/kappzzang/jeongsan/dto/request/CloseTeamRequest.java
@@ -1,0 +1,6 @@
+package kappzzang.jeongsan.dto.request;
+
+public record CloseTeamRequest(
+        Boolean isClosed
+) {
+}

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatusCode;
 public enum ErrorType {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "000", "사용자를 찾을 수 없습니다."),
-    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "000", "모임을 찾을 수 없습니다.");
+    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "000", "모임을 찾을 수 없습니다."),
+    TEAM_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "000", "이미 종료된 모임입니다.");
 
     private final HttpStatusCode httpStatusCode;
     private final String errorCode;

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatusCode;
 @Getter
 public enum ErrorType {
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "000", "사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "000", "사용자를 찾을 수 없습니다."),
+    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "000", "모임을 찾을 수 없습니다.");
 
     private final HttpStatusCode httpStatusCode;
     private final String errorCode;

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatusCode;
 public enum SuccessType {
 
     TEAM_CREATED(HttpStatus.CREATED, "모임이 생성되었습니다."),
-    TEAM_LIST_LOADED(HttpStatus.OK, "모임 목록을 불러오는 데 성공했습니다.");
+    TEAM_LIST_LOADED(HttpStatus.OK, "모임 목록을 불러오는 데 성공했습니다."),
+    TEAM_CLOSED(HttpStatus.NO_CONTENT, "모임이 종료되었습니다.");
 
     private final HttpStatusCode httpStatusCode;
     private final String message;

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatusCode;
 @Getter
 public enum SuccessType {
 
-    TEAM_CREATED(HttpStatus.CREATED, "모임이 생성되었습니다.");
+    TEAM_CREATED(HttpStatus.CREATED, "모임이 생성되었습니다."),
+    TEAM_LIST_LOADED(HttpStatus.OK, "모임 목록을 불러오는 데 성공했습니다.");
 
     private final HttpStatusCode httpStatusCode;
     private final String message;

--- a/src/main/java/kappzzang/jeongsan/service/TeamService.java
+++ b/src/main/java/kappzzang/jeongsan/service/TeamService.java
@@ -1,6 +1,10 @@
 package kappzzang.jeongsan.service;
 
+import kappzzang.jeongsan.domain.Team;
+import kappzzang.jeongsan.dto.request.CloseTeamRequest;
 import kappzzang.jeongsan.dto.response.TeamResponse;
+import kappzzang.jeongsan.global.common.enumeration.ErrorType;
+import kappzzang.jeongsan.global.exception.JeongsanException;
 import kappzzang.jeongsan.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,5 +24,12 @@ public class TeamService {
                 .stream()
                 .map(TeamResponse::from)
                 .toList();
+    }
+
+    @Transactional
+    public void closeTeam(Long teamId, CloseTeamRequest request) {
+        Team team = teamRepository.findById(teamId)
+            .orElseThrow(() -> new JeongsanException(ErrorType.TEAM_NOT_FOUND));
+        team.closeTeam(request.isClosed());
     }
 }


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 모임 종료 기능을 필드 변경으로 구현했습니다.
- 모임 목록 조회 기능에서 반환형을 JeongsanApiResponse를 사용하도록 변경했습니다.


### 🔍 참고 사항
- `isClosed`에 관한 조건문을 Team 도메인 내부에 넣어 이미 종료된 상황에 대한 예외를 처리했습니다.
- 현재 `isClosed`필드가 있는 이유는 메인 페이지에서 이미 종료된 모임도 확인하기 위해서 입니다. 그렇다면 closeTeam에 관해서는 요청이 항상 아래와 같이 온다고 가정하고 예외 처리를 추가로 해야될까요? 만약 그렇다면 추가적인 예외 처리를 할 생각입니다.
```json
{
  "isClosed": true
}
```

### 🐞현재 버그
X

### #️⃣ 연관 이슈(Git Close)
- #16 
- #23 
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)