### PR TITLE
Fix: 배포 스크립트에서 빌드된 jar 파일을 읽지 못하는 오류 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Login to Amazon ECR
         run: aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.ECR_REPOSITORY }}
 
+      - name: Download the JAR file
+        uses: actions/download-artifact@v4
+        with:
+          name: jeongsan-latest-jar
+          path: build/libs
+
       - name: Build the Docker image
         run: docker build -t ${{ secrets.ECR_REPOSITORY }} .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
           chmod +x ./gradlew
           ./gradlew clean build
 
+      - name: Upload the JAR file
+        uses: actions/upload-artifact@v4
+        with:
+          name: jeongsan-latest-jar
+          path: build/libs/jeongsan-latest.jar
+
       # Show test result
       - name: Show test result
         uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 현재 CI 스크립트에서 빌드된 JAR 파일을 CD 스크립트에서 읽지 못하는 문제가 있음
- 이를 해결하기 위해 upload&download artifact action을 이용해 CI에서 빌드된 후 jar 파일을 업로드하고, CD 에서 다운로드하는 방식으로 실행

### 🔍 참고 사항
- 위클리 주간 pr의 작업내용에 이 pr 넘버를 올려주면 될 것 같습니다.
- 테스트를 위한 approve 스킵 후 병합

### ⚠️ 의논 필요
- 

### 🐞현재 버그
- 실제 테스트 필요
- Master 브랜치 직접 병합을 통해 테스트

### #️⃣ 연관 이슈(Git Close)
- close #29 
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
