### PR TITLE
Feature/issue#28: 모임 초대 수락 -> 모임 참여 API 구현

### DIFF
--- a/src/main/java/kappzzang/jeongsan/controller/MemberController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/MemberController.java
@@ -1,0 +1,32 @@
+package kappzzang.jeongsan.controller;
+
+import static kappzzang.jeongsan.global.common.enumeration.SuccessType.JOIN_SUCCESS;
+
+import kappzzang.jeongsan.controller.docs.MemberControllerInterface;
+import kappzzang.jeongsan.dto.request.JoinTeamRequest;
+import kappzzang.jeongsan.global.common.JeongsanApiResponse;
+import kappzzang.jeongsan.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+public class MemberController implements MemberControllerInterface {
+
+    private final MemberService memberService;
+
+    @Override
+    @PostMapping("/join/{teamId}")
+    public ResponseEntity<JeongsanApiResponse<Void>> joinTeam(@PathVariable("teamId") Long teamId,
+        @RequestBody JoinTeamRequest request) {
+
+        memberService.acceptInvite(teamId, request.memberId());
+        return JeongsanApiResponse.success(JOIN_SUCCESS);
+    }
+}

--- a/src/main/java/kappzzang/jeongsan/controller/docs/MemberControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/MemberControllerInterface.java
@@ -1,0 +1,21 @@
+package kappzzang.jeongsan.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kappzzang.jeongsan.dto.request.JoinTeamRequest;
+import kappzzang.jeongsan.global.common.JeongsanApiResponse;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "회원 관리", description = "JWT 반환, 멤버 그룹 참여, 초대 현황 등을 관리하는 API Controller")
+public interface MemberControllerInterface {
+
+    @Operation(summary = "모임 초대 수락 API", description = "모임 초대 링크를 받은 사용자가 모임 참여를 수락하여 모임에 참여하도록 하는 API")
+    @ApiResponses({@ApiResponse(responseCode = "204", description = "모임 초대 수락, 모임 참여 성공"),
+        @ApiResponse(responseCode = "400", description = "모임에 초대 되지 않은 멤버. (ErrorCode-E400002"),
+        @ApiResponse(responseCode = "400", description = "이미 모임에 참여중인 멤버. (ErrorCode-E400003)"),
+        @ApiResponse(responseCode = "404", description = "잘못된 teamId, 모임을 찾을 수 없음. (ErrorCode-E404002)"),
+        @ApiResponse(responseCode = "404", description = "잘못된 memberId, 사용자를 찾을 수 없음. (ErrorCode-E404003)")})
+    ResponseEntity<JeongsanApiResponse<Void>> joinTeam(Long teamId, JoinTeamRequest request);
+}

--- a/src/main/java/kappzzang/jeongsan/controller/docs/MemberControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/MemberControllerInterface.java
@@ -8,7 +8,7 @@ import kappzzang.jeongsan.dto.request.JoinTeamRequest;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
 import org.springframework.http.ResponseEntity;
 
-@Tag(name = "회원 관리", description = "JWT 반환, 멤버 그룹 참여, 초대 현황 등을 관리하는 API Controller")
+@Tag(name = "회원 관리", description = "JWT 반환, 멤버 그룹 참여, 초대 현황 등을 관리하는 API")
 public interface MemberControllerInterface {
 
     @Operation(summary = "모임 초대 수락 API", description = "모임 초대 링크를 받은 사용자가 모임 참여를 수락하여 모임에 참여하도록 하는 API")

--- a/src/main/java/kappzzang/jeongsan/domain/TeamMember.java
+++ b/src/main/java/kappzzang/jeongsan/domain/TeamMember.java
@@ -1,11 +1,14 @@
 package kappzzang.jeongsan.domain;
 
+import static kappzzang.jeongsan.global.common.enumeration.ErrorType.ALREADY_JOINED_MEMBER;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import kappzzang.jeongsan.global.exception.JeongsanException;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -29,4 +32,10 @@ public class TeamMember extends BaseEntity {
     private Boolean isOwner;
     private Boolean isInviteAccepted;
 
+    public void acceptInvite() {
+        if (this.isInviteAccepted) {
+            throw new JeongsanException(ALREADY_JOINED_MEMBER);
+        }
+        this.isInviteAccepted = true;
+    }
 }

--- a/src/main/java/kappzzang/jeongsan/dto/request/JoinTeamRequest.java
+++ b/src/main/java/kappzzang/jeongsan/dto/request/JoinTeamRequest.java
@@ -1,0 +1,5 @@
+package kappzzang.jeongsan.dto.request;
+
+public record JoinTeamRequest(Long memberId) {
+
+}

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
@@ -9,6 +9,8 @@ public enum ErrorType {
 
     // 400 BAD_REQUEST
     TEAM_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "E400001", "이미 종료된 모임입니다."),
+    NOT_INVITED_MEMBER(HttpStatus.BAD_REQUEST, "E400002", "해당 모임에 초대되지 않은 멤버입니다."),
+    ALREADY_JOINED_MEMBER(HttpStatus.BAD_REQUEST, "E400003", "이미 모임에 참여한 멤버입니다."),
 
     // 401 UNAUTHORIZED
     JWT_SIGNATURE_INVALID(HttpStatus.UNAUTHORIZED, "E401001", "토큰 서명이 유효하지 않습니다."),

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
@@ -15,7 +15,8 @@ public enum SuccessType {
     TEAM_CREATED(HttpStatus.CREATED, "모임이 생성되었습니다."),
 
     //204 NO_CONTENT
-    TEAM_CLOSED(HttpStatus.NO_CONTENT, "모임이 종료되었습니다.");
+    TEAM_CLOSED(HttpStatus.NO_CONTENT, "모임이 종료되었습니다."),
+    JOIN_SUCCESS(HttpStatus.NO_CONTENT, "모임 멤버로 참여되었습니다.");
 
 
     private final HttpStatusCode httpStatusCode;

--- a/src/main/java/kappzzang/jeongsan/repository/MemberRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/MemberRepository.java
@@ -1,10 +1,8 @@
 package kappzzang.jeongsan.repository;
 
-import java.util.Optional;
 import kappzzang.jeongsan.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findMemberById(Long id);
 }

--- a/src/main/java/kappzzang/jeongsan/repository/MemberRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package kappzzang.jeongsan.repository;
+
+import java.util.Optional;
+import kappzzang.jeongsan.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findMemberById(Long id);
+
+}

--- a/src/main/java/kappzzang/jeongsan/repository/MemberRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/MemberRepository.java
@@ -7,5 +7,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findMemberById(Long id);
-
 }

--- a/src/main/java/kappzzang/jeongsan/repository/TeamMemberRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/TeamMemberRepository.java
@@ -1,0 +1,12 @@
+package kappzzang.jeongsan.repository;
+
+import java.util.Optional;
+import kappzzang.jeongsan.domain.Member;
+import kappzzang.jeongsan.domain.Team;
+import kappzzang.jeongsan.domain.TeamMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+
+    Optional<TeamMember> findTeamMemberByTeamAndMember(Team team, Member member);
+}

--- a/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
@@ -1,7 +1,6 @@
 package kappzzang.jeongsan.repository;
 
 import java.util.List;
-import java.util.Optional;
 import kappzzang.jeongsan.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,6 +12,4 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
         "JOIN FETCH tm.member " +
         "WHERE t.isClosed = :isClosed")
     List<Team> findByIsClosed(Boolean isClosed);
-
-    Optional<Team> findTeamById(Long id);
 }

--- a/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
@@ -1,6 +1,7 @@
 package kappzzang.jeongsan.repository;
 
 import java.util.List;
+import java.util.Optional;
 import kappzzang.jeongsan.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,4 +13,6 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
         "JOIN FETCH tm.member " +
         "WHERE t.isClosed = :isClosed")
     List<Team> findByIsClosed(Boolean isClosed);
+
+    Optional<Team> findTeamById(Long id);
 }

--- a/src/main/java/kappzzang/jeongsan/service/MemberService.java
+++ b/src/main/java/kappzzang/jeongsan/service/MemberService.java
@@ -1,0 +1,38 @@
+package kappzzang.jeongsan.service;
+
+import static kappzzang.jeongsan.global.common.enumeration.ErrorType.NOT_INVITED_MEMBER;
+import static kappzzang.jeongsan.global.common.enumeration.ErrorType.TEAM_NOT_FOUND;
+import static kappzzang.jeongsan.global.common.enumeration.ErrorType.USER_NOT_FOUND;
+
+import jakarta.transaction.Transactional;
+import kappzzang.jeongsan.domain.Member;
+import kappzzang.jeongsan.domain.Team;
+import kappzzang.jeongsan.domain.TeamMember;
+import kappzzang.jeongsan.global.exception.JeongsanException;
+import kappzzang.jeongsan.repository.MemberRepository;
+import kappzzang.jeongsan.repository.TeamMemberRepository;
+import kappzzang.jeongsan.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final TeamRepository teamRepository;
+    private final MemberRepository memberRepository;
+    private final TeamMemberRepository teamMemberRepository;
+
+    @Transactional
+    public void acceptInvite(Long teamId, Long memberId) {
+
+        Team team = teamRepository.findTeamById(teamId)
+            .orElseThrow(() -> new JeongsanException(TEAM_NOT_FOUND));
+        Member member = memberRepository.findMemberById(memberId)
+            .orElseThrow(() -> new JeongsanException(USER_NOT_FOUND));
+        TeamMember teamMember = teamMemberRepository.findTeamMemberByTeamAndMember(team, member)
+            .orElseThrow(() -> new JeongsanException(NOT_INVITED_MEMBER));
+
+        teamMember.acceptInvite();
+    }
+}

--- a/src/main/java/kappzzang/jeongsan/service/MemberService.java
+++ b/src/main/java/kappzzang/jeongsan/service/MemberService.java
@@ -26,9 +26,9 @@ public class MemberService {
     @Transactional
     public void acceptInvite(Long teamId, Long memberId) {
 
-        Team team = teamRepository.findTeamById(teamId)
+        Team team = teamRepository.findById(teamId)
             .orElseThrow(() -> new JeongsanException(TEAM_NOT_FOUND));
-        Member member = memberRepository.findMemberById(memberId)
+        Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new JeongsanException(USER_NOT_FOUND));
         TeamMember teamMember = teamMemberRepository.findTeamMemberByTeamAndMember(team, member)
             .orElseThrow(() -> new JeongsanException(NOT_INVITED_MEMBER));


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 모임 초대 받은 사용자가 초대에 수락하여 모임 참여하는 api

### 🔍 참고 사항
- 일단 API 명세에 따라 `memberId`를 받고 있는데, 어차피 토큰에 인증 된 멤버 정보(id)가 있을 예정이라 리팩토링 시 반영하도록 하겠습니다.
- swagger에 명시할 내용을 관리하기 위해 컨트롤러의 interface를 정의하였고, `docs` 라는 패키지에 넣어두었습니다.

### ⚠️ 의논 필요
- 컨트롤러 인터페이스 관리 `controller.docs` 괜찮나요?! 

### 🐞현재 버그
X

### #️⃣ 연관 이슈(Git Close)
- #28 
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
