### PR TITLE
Feature/issue#21: 지출 목록 (정산 중, 완료) 조회 기능 구현

### DIFF
--- a/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
@@ -35,7 +35,7 @@ public class ExpenseController {
         }
 
         if (status == Status.ONGOING && isChecked == null) {
-            throw new JeongsanException(ErrorType.EXPENSE_BAD_REQUEST);
+            throw new JeongsanException(ErrorType.EXPENSE_MISSING_PARAM);
         }
 
         return JeongsanApiResponse.success(SuccessType.EXPENSE_LIST_LOADED,

--- a/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
@@ -1,0 +1,44 @@
+package kappzzang.jeongsan.controller;
+
+import kappzzang.jeongsan.dto.response.ExpenseResponse;
+import kappzzang.jeongsan.global.common.JeongsanApiResponse;
+import kappzzang.jeongsan.global.common.enumeration.ErrorType;
+import kappzzang.jeongsan.global.common.enumeration.Status;
+import kappzzang.jeongsan.global.common.enumeration.SuccessType;
+import kappzzang.jeongsan.global.exception.JeongsanException;
+import kappzzang.jeongsan.service.ExpenseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/expenses")
+@RequiredArgsConstructor
+public class ExpenseController {
+
+    private final ExpenseService expenseService;
+
+    @GetMapping("{teamId}")
+    public ResponseEntity<JeongsanApiResponse<ExpenseResponse>> getAllExpenses(
+        @PathVariable Long teamId,
+        @RequestParam String state,
+        @RequestParam(required = false) Boolean isChecked) {
+        Status status;
+        try {
+            status = Status.valueOf(state.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new JeongsanException(ErrorType.EXPENSE_INVALID_STATE);
+        }
+
+        if (status == Status.ONGOING && isChecked == null) {
+            throw new JeongsanException(ErrorType.EXPENSE_BAD_REQUEST);
+        }
+
+        return JeongsanApiResponse.success(SuccessType.EXPENSE_LIST_LOADED,
+            expenseService.getResponses(1L, teamId, status, isChecked));
+    }
+}

--- a/src/main/java/kappzzang/jeongsan/controller/TeamController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/TeamController.java
@@ -11,10 +11,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@RestController("/api/teams")
+@RestController
+@RequestMapping("/api/teams")
 public class TeamController {
 
     private final TeamService teamService;

--- a/src/main/java/kappzzang/jeongsan/dto/CategoryDto.java
+++ b/src/main/java/kappzzang/jeongsan/dto/CategoryDto.java
@@ -1,0 +1,14 @@
+package kappzzang.jeongsan.dto;
+
+import kappzzang.jeongsan.domain.Category;
+
+public record CategoryDto(
+    String name,
+    String color
+) {
+
+    public static CategoryDto from(Category category) {
+        return new CategoryDto(category.getName(), category.getColor());
+    }
+
+}

--- a/src/main/java/kappzzang/jeongsan/dto/response/ExpenseResponse.java
+++ b/src/main/java/kappzzang/jeongsan/dto/response/ExpenseResponse.java
@@ -1,0 +1,43 @@
+package kappzzang.jeongsan.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import kappzzang.jeongsan.domain.Expense;
+import kappzzang.jeongsan.dto.CategoryDto;
+import kappzzang.jeongsan.global.common.enumeration.Status;
+
+public record ExpenseResponse(
+    List<ExpenseItem> expenseList,
+    Boolean checked,
+    Integer totalPrice
+) {
+
+    public record ExpenseItem(
+        Long expenseId,
+        String title,
+        Integer totalPrice,
+        LocalDateTime createdAt,
+        Status state,
+        CategoryDto category
+    ) {
+
+        public static ExpenseItem from(Expense expense) {
+            return new ExpenseItem(
+                expense.getId(),
+                expense.getTitle(),
+                expense.getTotalPrice(),
+                expense.getCreatedAt(),
+                expense.getStatus(),
+                CategoryDto.from(expense.getCategory())
+            );
+        }
+    }
+
+    public static ExpenseResponse of(List<Expense> expenseList, Boolean isChecked,
+        Integer totalPrice) {
+        List<ExpenseItem> expenseItems = expenseList.stream()
+            .map(ExpenseItem::from)
+            .toList();
+        return new ExpenseResponse(expenseItems, isChecked, totalPrice);
+    }
+}

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
@@ -9,6 +9,8 @@ public enum ErrorType {
 
     // 400 BAD_REQUEST
     TEAM_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "E400001", "이미 종료된 모임입니다."),
+    EXPENSE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "E400002", "잘못된 요청입니다."),
+    EXPENSE_INVALID_STATE(HttpStatus.BAD_REQUEST, "E400003", "잘못된 state 값 요청입니다."),
 
     // 401 UNAUTHORIZED
     JWT_SIGNATURE_INVALID(HttpStatus.UNAUTHORIZED, "E401001", "토큰 서명이 유효하지 않습니다."),

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
@@ -9,7 +9,7 @@ public enum ErrorType {
 
     // 400 BAD_REQUEST
     TEAM_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "E400001", "이미 종료된 모임입니다."),
-    EXPENSE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "E400002", "잘못된 요청입니다."),
+    EXPENSE_MISSING_PARAM(HttpStatus.BAD_REQUEST, "E400002", "누락된 쿼리 파라미터가 존재합니다."),
     EXPENSE_INVALID_STATE(HttpStatus.BAD_REQUEST, "E400003", "잘못된 state 값 요청입니다."),
 
     // 401 UNAUTHORIZED

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
@@ -10,6 +10,7 @@ public enum SuccessType {
     // 200 OK
     TEAM_LIST_LOADED(HttpStatus.OK, "모임 목록을 불러오는 데 성공했습니다."),
     RECEIPT_ANALYSIS_SUCCESS(HttpStatus.OK, "영수증 분석을 성공하였습니다."),
+    EXPENSE_LIST_LOADED(HttpStatus.OK, "지출 목록을 불러오는 데 성공했습니다"),
 
     // 201 CREATED
     TEAM_CREATED(HttpStatus.CREATED, "모임이 생성되었습니다."),

--- a/src/main/java/kappzzang/jeongsan/repository/ExpenseRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/ExpenseRepository.java
@@ -1,0 +1,32 @@
+package kappzzang.jeongsan.repository;
+
+import java.util.List;
+import kappzzang.jeongsan.domain.Expense;
+import kappzzang.jeongsan.global.common.enumeration.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+
+    @Query("SELECT e FROM Expense e "
+        + "JOIN FETCH e.items "
+        + "WHERE e.team.id = :teamId "
+        + "AND e.status = :status")
+    List<Expense> findByTeamIdAndStatus(Long teamId, Status status);
+
+//    @Query("SELECT e FROM Expense e "
+//        + "WHERE e.team.id = :teamId "
+//        + "AND e.status = :status "
+//        + "AND ("
+//        + "    EXISTS ("
+//        + "        SELECT 1 FROM PersonalExpense pe "
+//        + "        WHERE pe.member.id = :memberId "
+//        + "        AND pe.item.id IN ("
+//        + "            SELECT i.id FROM Item i "
+//        + "            WHERE i.expense.id = e.id"
+//        + "        )"
+//        + "    ) = :isChecked"
+//        + ")")
+//    List<Expense> findByTeamIdStatusAndIsChecked(Long teamId, Status status, Long memberId,
+//        Boolean isChecked);
+}

--- a/src/main/java/kappzzang/jeongsan/repository/ItemRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/ItemRepository.java
@@ -1,0 +1,10 @@
+package kappzzang.jeongsan.repository;
+
+import java.util.List;
+import kappzzang.jeongsan.domain.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+
+    List<Item> findAllByExpenseId(Long expenseId);
+}

--- a/src/main/java/kappzzang/jeongsan/repository/PersonalExpenseRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/PersonalExpenseRepository.java
@@ -1,0 +1,17 @@
+package kappzzang.jeongsan.repository;
+
+import java.util.List;
+import kappzzang.jeongsan.domain.PersonalExpense;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PersonalExpenseRepository extends JpaRepository<PersonalExpense, Long> {
+
+    @Query("SELECT COUNT(pe) FROM PersonalExpense pe "
+        + "WHERE pe.member.id = :memberId "
+        + "AND pe.item.id "
+        + "IN :itemIds")
+    Long countByMemberIdAndItemIds(@Param("memberId") Long memberId,
+        @Param("itemIds") List<Long> itemIds);
+}

--- a/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
@@ -1,0 +1,48 @@
+package kappzzang.jeongsan.service;
+
+import java.util.List;
+import kappzzang.jeongsan.domain.Expense;
+import kappzzang.jeongsan.domain.Item;
+import kappzzang.jeongsan.dto.response.ExpenseResponse;
+import kappzzang.jeongsan.global.common.enumeration.Status;
+import kappzzang.jeongsan.repository.ExpenseRepository;
+import kappzzang.jeongsan.repository.ItemRepository;
+import kappzzang.jeongsan.repository.PersonalExpenseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ExpenseService {
+
+    private final ExpenseRepository expenseRepository;
+    private final PersonalExpenseRepository personalExpenseRepository;
+    private final ItemRepository itemRepository;
+
+    public ExpenseResponse getResponses(Long memberId, Long teamId, Status status,
+        Boolean isChecked) {
+        List<Expense> expenses = expenseRepository.findByTeamIdAndStatus(teamId, status);
+        List<Expense> filteredExpenses = expenses.stream()
+            .filter(expense -> isChecked.equals(isExpenseChecked(expense, memberId)))
+            .toList();
+
+        Integer totalPrice = expenses.stream()
+            .mapToInt(Expense::getTotalPrice)
+            .sum();
+
+        return ExpenseResponse.of(filteredExpenses, isChecked, totalPrice);
+    }
+
+    private Boolean isExpenseChecked(Expense expense, Long memberId) {
+        List<Long> itemIds = itemRepository.findAllByExpenseId(expense.getId())
+            .stream()
+            .map(Item::getId)
+            .toList();
+        Long countOfPersonalExpenses = personalExpenseRepository.countByMemberIdAndItemIds(memberId,
+            itemIds);
+
+        return countOfPersonalExpenses.equals((long) itemIds.size());
+    }
+}

--- a/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
@@ -22,6 +22,7 @@ public class ExpenseService {
     private final PersonalExpenseRepository personalExpenseRepository;
     private final ItemRepository itemRepository;
 
+    @Transactional(readOnly = true)
     public ExpenseResponse getResponses(Long memberId, Long teamId, Status status,
         Boolean isChecked) {
         List<Expense> expenses = expenseRepository.findByTeamIdAndStatus(teamId, status);

--- a/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
@@ -1,5 +1,6 @@
 package kappzzang.jeongsan.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import kappzzang.jeongsan.domain.Expense;
 import kappzzang.jeongsan.domain.Item;
@@ -24,9 +25,19 @@ public class ExpenseService {
     public ExpenseResponse getResponses(Long memberId, Long teamId, Status status,
         Boolean isChecked) {
         List<Expense> expenses = expenseRepository.findByTeamIdAndStatus(teamId, status);
-        List<Expense> filteredExpenses = expenses.stream()
-            .filter(expense -> isChecked.equals(isExpenseChecked(expense, memberId)))
-            .toList();
+        List<Expense> filteredExpenses;
+
+        // PENDING 구현 시 리팩토링 필요
+        if (status == Status.ONGOING) {
+            filteredExpenses = expenses.stream()
+                .filter(expense -> isChecked.equals(isExpenseChecked(expense, memberId)))
+                .toList();
+        } else if (status == Status.COMPLETED) {
+            filteredExpenses = expenses;
+        } else {
+            // PENDING에서 사용
+            filteredExpenses = new ArrayList<>();
+        }
 
         Integer totalPrice = expenses.stream()
             .mapToInt(Expense::getTotalPrice)


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 지출 목록 페이지 중 정산 중, 송금완료 페이지에 조회될 정보 api를 구현했습니다.
- isChecked는 사용자가 하나의 Expense의 모든 item에 대한 레코드가 존재할 때 true, 그 외의 경우 false로 생각했고 구현 로직을 `{조건에 맞는 레코드 개수} == {expense.item 개수}`로 하였습니다.
- status에 관한 부분은 서비스 코드에서 if-else 문으로 구현했습니다.
  - `PENDING`의 구현에 따라 리팩토링이 필요할 수 있습니다.

### 🔍 참고 사항
- Controller -> Service에 memberId 인자를 `1L`로 하드코딩했습니다.
- 여러 데이터가 복합적으로 필요해 테스트코드를 작성하지 않았습니다.
  - 테스트를 위한 더미데이터를 만들 필요가 있을 것 같습니다.

### ⚠️ 의논 필요
```java
@Query("SELECT e FROM Expense e "
    + "WHERE e.team.id = :teamId "
    + "AND e.status = :status "
    + "AND ("
    + "    EXISTS ("
    + "        SELECT 1 FROM PersonalExpense pe "
    + "        WHERE pe.member.id = :memberId "
    + "        AND pe.item.id IN ("
    + "            SELECT i.id FROM Item i "
    + "            WHERE i.expense.id = e.id"
    + "        )"
    + "    ) = :isChecked"
    + ")")
List<Expense> findByTeamIdStatusAndIsChecked(Long teamId, Status status, Long memberId,
    Boolean isChecked);
```
- ExpenseRepository에 주석으로 처리한 코드입니다.
- 위 코드로 `isChecked`에 관한 부분을 서비스 로직으로 처리하는 것이 아닌 쿼리로 처리하는 방법이 있습니다.
- 혹시 어떤 방법이 좋을까요?

### 🐞현재 버그
- 

### #️⃣ 연관 이슈(Git Close)
- close #21 
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
