### PR TITLE
Document/issue#46: 지출 내역 및 모임 관련 API에 대한 명세 작성

### DIFF
--- a/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
@@ -1,5 +1,6 @@
 package kappzzang.jeongsan.controller;
 
+import kappzzang.jeongsan.controller.docs.ExpenseControllerInterface;
 import kappzzang.jeongsan.dto.response.ExpenseResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
@@ -18,10 +19,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/expenses")
 @RequiredArgsConstructor
-public class ExpenseController {
+public class ExpenseController implements ExpenseControllerInterface {
 
     private final ExpenseService expenseService;
 
+    @Override
     @GetMapping("{teamId}")
     public ResponseEntity<JeongsanApiResponse<ExpenseResponse>> getAllExpenses(
         @PathVariable Long teamId,

--- a/src/main/java/kappzzang/jeongsan/controller/TeamController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/TeamController.java
@@ -2,6 +2,7 @@ package kappzzang.jeongsan.controller;
 
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import java.util.List;
+import kappzzang.jeongsan.controller.docs.TeamControllerInterface;
 import kappzzang.jeongsan.dto.request.CloseTeamRequest;
 import kappzzang.jeongsan.dto.response.TeamResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
@@ -17,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/teams")
-public class TeamController {
+public class TeamController implements TeamControllerInterface {
 
     private final TeamService teamService;
 
@@ -25,6 +26,7 @@ public class TeamController {
         this.teamService = teamService;
     }
 
+    @Override
     @GetMapping
     public ResponseEntity<JeongsanApiResponse<List<TeamResponse>>> getTeams(
         @RequestParam("isClosed") Boolean isClosed) {
@@ -33,6 +35,7 @@ public class TeamController {
         return JeongsanApiResponse.success(SuccessType.TEAM_LIST_LOADED, data);
     }
 
+    @Override
     @PatchMapping("/{teamId}")
     public ResponseEntity<JeongsanApiResponse<Void>> closeTeam(
         @PathVariable("teamId") Long teamId, @RequestBody CloseTeamRequest request) {

--- a/src/main/java/kappzzang/jeongsan/controller/TeamController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/TeamController.java
@@ -8,6 +8,7 @@ import kappzzang.jeongsan.dto.response.TeamResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
 import kappzzang.jeongsan.global.common.enumeration.SuccessType;
 import kappzzang.jeongsan.service.TeamService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -18,13 +19,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/teams")
+@RequiredArgsConstructor
 public class TeamController implements TeamControllerInterface {
 
     private final TeamService teamService;
-
-    public TeamController(TeamService teamService) {
-        this.teamService = teamService;
-    }
 
     @Override
     @GetMapping

--- a/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
@@ -12,7 +12,7 @@ import kappzzang.jeongsan.dto.response.ExpenseResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
 import org.springframework.http.ResponseEntity;
 
-@Tag(name = "지출 목록 관리 API", description = "지출 내역에 대한 조회, 저장 등 관리하는 API")
+@Tag(name = "지출 목록 관리", description = "지출 내역에 대한 조회, 저장 등 관리하는 API")
 public interface ExpenseControllerInterface {
 
     @Operation(summary = "지출 내역 목록 조회 API", description = "지출 내역 목록을 쿼리 파라미터의 조건에 따라 조회하는 API")

--- a/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
@@ -1,0 +1,33 @@
+package kappzzang.jeongsan.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kappzzang.jeongsan.dto.response.ExpenseResponse;
+import kappzzang.jeongsan.global.common.JeongsanApiResponse;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "지출 목록 관리 API", description = "지출 내역에 대한 조회, 저장 등 관리하는 API")
+public interface ExpenseControllerInterface {
+
+    @Operation(summary = "지출 내역 목록 조회 API", description = "지출 내역 목록을 쿼리 파라미터의 조건에 따라 조회하는 API")
+    @Parameters({
+        @Parameter(name = "teamId", description = "지출 내역 조회를 원하는 모임의 ID"),
+        @Parameter(name = "state", description = "지출 내역의 상태를 지정하는 쿼리 파라미터(`ongoing`, `pending`, `completed`)"),
+        @Parameter(name = "isChecked", description = "`정산 중`상태의 지출 목록 중 사용자의 현재 선택한 상태를 지정하는 쿼리 파라미터")
+    })
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "지출 내역 목록을 성공적으로 조회",
+            content = @Content(schema = @Schema(implementation = ExpenseResponse.class))),
+        @ApiResponse(responseCode = "400", description = "누락된 쿼리 파라미터가 존재 (ErrorCode=E400)"),
+        @ApiResponse(responseCode = "400", description = "`state`에 잘못된 값 입력. `ongoing`, `pending`, `completed`만 가능 (ErrorCode-E400)"),
+        @ApiResponse(responseCode = "404", description = "`teamId`에 해당하는 모임이 존재하지 않음. (ErrorCode-E404)")
+    })
+    ResponseEntity<JeongsanApiResponse<ExpenseResponse>> getAllExpenses(Long teamId, String state,
+        Boolean isChecked);
+}

--- a/src/main/java/kappzzang/jeongsan/controller/docs/TeamControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/TeamControllerInterface.java
@@ -31,7 +31,8 @@ public interface TeamControllerInterface {
         @Parameter(name = "request", description = "`isClosed`에 대한 정보. 사용되지 않을 가능성 있음")
     })
     @ApiResponses({
-        @ApiResponse(responseCode = "204", description = "모임을 `종료` 상태로 변경"),
+        @ApiResponse(responseCode = "204", description = "모임을 `종료` 상태로 변경",
+        content = @Content),
         @ApiResponse(responseCode = "400", description = "모임이 이미 종료된 상태 (ErrorCode-E400001)"),
         @ApiResponse(responseCode = "404", description = "`teamId`에 해당하는 모임을 찾을 수 없음 (ErrorCode-E404002)")
     })

--- a/src/main/java/kappzzang/jeongsan/controller/docs/TeamControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/TeamControllerInterface.java
@@ -1,0 +1,39 @@
+package kappzzang.jeongsan.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import kappzzang.jeongsan.dto.request.CloseTeamRequest;
+import kappzzang.jeongsan.dto.response.TeamResponse;
+import kappzzang.jeongsan.global.common.JeongsanApiResponse;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "모임 관리", description = "모임 목록 생성, 조회, 종료 등을 실행하는 API")
+public interface TeamControllerInterface {
+
+    @Operation(summary = "모임 목록 조회 API", description = "모임 목록을 조회하는 API")
+    @Parameter(name = "isClosed", description = "모임의 현재 상태(진행 중, 종료)")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "모임 목록 조회 성공",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = TeamResponse.class))),
+    })
+    ResponseEntity<JeongsanApiResponse<List<TeamResponse>>> getTeams(Boolean isClosed);
+
+    @Operation(summary = "모임 종료 API", description = "선택한 모임의 상태를 \"종료\"로 변경하는 API")
+    @Parameters({
+        @Parameter(name = "teamId", description = "종료를 원하는 모임의 id"),
+        @Parameter(name = "request", description = "`isClosed`에 대한 정보. 사용되지 않을 가능성 있음")
+    })
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "모임을 `종료` 상태로 변경"),
+        @ApiResponse(responseCode = "400", description = "모임이 이미 종료된 상태 (ErrorCode-E400001)"),
+        @ApiResponse(responseCode = "404", description = "`teamId`에 해당하는 모임을 찾을 수 없음 (ErrorCode-E404002)")
+    })
+    ResponseEntity<JeongsanApiResponse<Void>> closeTeam(Long teamId, CloseTeamRequest request);
+}


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 작업했던 #16 #21 에 관한 API 명세를 Swagger&Interface를 이용해 작성했습니다.

![image](https://github.com/user-attachments/assets/b7d5f10f-006e-4d09-8427-807deecd638d)
- 응답이 `204 No Content`인 경우 응답 데이터를 명시적으로 비워뒀습니다.

![image](https://github.com/user-attachments/assets/4b2f9f8f-eedd-42a6-9781-775f3262cec8)
- 성공했는 경우에 대한 응답 데이터를 표시했습니다. `content`를 비워둘 경우 잘못된 데이터가 들어갈 수 있습니다

### 🔍 참고 사항
![image](https://github.com/user-attachments/assets/73e5830c-f64a-488c-b25b-61511ccdf574)
- 에러 코드의 경우 일괄 수정한다고 하여 상태코드까지만 작성했습니다.

### ⚠️ 의논 필요
- content에 JeongsanApiResponse의 `data`에 해당하는 부분만 작성하는 것이 좋을 것 같습니다.

### 🐞현재 버그
- 현재 버전에 버그가 있다면 작성

### #️⃣ 연관 이슈(Git Close)
- close #46 
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
