### PR TITLE
Feature/issue#67: 모임 생성 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
 	// JWT

--- a/src/main/java/kappzzang/jeongsan/controller/TeamController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/TeamController.java
@@ -1,9 +1,12 @@
 package kappzzang.jeongsan.controller;
 
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import jakarta.validation.Valid;
 import java.util.List;
 import kappzzang.jeongsan.controller.docs.TeamControllerInterface;
 import kappzzang.jeongsan.dto.request.CloseTeamRequest;
+import kappzzang.jeongsan.dto.request.CreateTeamRequest;
+import kappzzang.jeongsan.dto.response.CreateTeamResponse;
 import kappzzang.jeongsan.dto.response.InvitationStatusResponse;
 import kappzzang.jeongsan.dto.response.TeamResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
@@ -11,9 +14,11 @@ import kappzzang.jeongsan.global.common.enumeration.SuccessType;
 import kappzzang.jeongsan.service.TeamService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,6 +37,14 @@ public class TeamController implements TeamControllerInterface {
         List<TeamResponse> data = teamService.getTeamsByIsClosed(isClosed);
 
         return JeongsanApiResponse.success(SuccessType.TEAM_LIST_LOADED, data);
+    }
+
+    @Override
+    @PostMapping
+    public ResponseEntity<JeongsanApiResponse<CreateTeamResponse>> createTeam(
+        @AuthenticationPrincipal Long memberId, @Valid @RequestBody CreateTeamRequest request) {
+        CreateTeamResponse data = teamService.createTeam(memberId, request);
+        return JeongsanApiResponse.success(SuccessType.TEAM_CREATED, data);
     }
 
     @Override

--- a/src/main/java/kappzzang/jeongsan/controller/docs/TeamControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/TeamControllerInterface.java
@@ -28,6 +28,17 @@ public interface TeamControllerInterface {
     })
     ResponseEntity<JeongsanApiResponse<List<TeamResponse>>> getTeams(Boolean isClosed);
 
+    @Operation(summary = "모임 생성 API", description = "요청한 사용자가 주인으로 모임을 생성하는 API")
+    @Parameters({
+        @Parameter(name = "name", description = "15글자 이내의 모임 이름. 모임의 owner 기준 동일한 모임 이름을 사용할 수 없음"),
+        @Parameter(name = "subject", description = "모임의 목적. 이모지 사용"),
+        @Parameter(name = "members", description = "모임에 초대할 사용자들 ID")
+    })
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "모임 생성 성공"),
+        @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음(ErrorCode-E404001)"),
+        @ApiResponse(responseCode = "409", description = "중복된 모임 이름이 존재함(ErrorCode-E409)")
+    })
     ResponseEntity<JeongsanApiResponse<CreateTeamResponse>> createTeam(Long memberId, CreateTeamRequest request);
 
     @Operation(summary = "모임 종료 API", description = "선택한 모임의 상태를 \"종료\"로 변경하는 API")

--- a/src/main/java/kappzzang/jeongsan/controller/docs/TeamControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/TeamControllerInterface.java
@@ -10,6 +10,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import kappzzang.jeongsan.dto.request.CloseTeamRequest;
+import kappzzang.jeongsan.dto.request.CreateTeamRequest;
+import kappzzang.jeongsan.dto.response.CreateTeamResponse;
 import kappzzang.jeongsan.dto.response.InvitationStatusResponse;
 import kappzzang.jeongsan.dto.response.TeamResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
@@ -25,6 +27,8 @@ public interface TeamControllerInterface {
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = TeamResponse.class))),
     })
     ResponseEntity<JeongsanApiResponse<List<TeamResponse>>> getTeams(Boolean isClosed);
+
+    ResponseEntity<JeongsanApiResponse<CreateTeamResponse>> createTeam(Long memberId, CreateTeamRequest request);
 
     @Operation(summary = "모임 종료 API", description = "선택한 모임의 상태를 \"종료\"로 변경하는 API")
     @Parameters({

--- a/src/main/java/kappzzang/jeongsan/domain/Team.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Team.java
@@ -1,5 +1,6 @@
 package kappzzang.jeongsan.domain;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -28,7 +29,7 @@ public class Team extends BaseEntity {
     private String subject; //이모지 저장 필드
     private Boolean isClosed;
 
-    @OneToMany(mappedBy = "team")
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TeamMember> teamMemberList;
 
     public Team(String name, String subject) {

--- a/src/main/java/kappzzang/jeongsan/domain/Team.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Team.java
@@ -5,7 +5,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
 import kappzzang.jeongsan.global.exception.JeongsanException;
 import lombok.Getter;
@@ -22,11 +24,23 @@ public class Team extends BaseEntity {
     private Long id;
 
     private String name;
+
     private String subject; //이모지 저장 필드
     private Boolean isClosed;
 
     @OneToMany(mappedBy = "team")
     private List<TeamMember> teamMemberList;
+
+    public Team(String name, String subject) {
+        this.name = name;
+        this.subject = subject;
+        this.isClosed = false;
+        teamMemberList = new ArrayList<>();
+    }
+
+    public static Team createTeam(String name, String subject) {
+        return new Team(name, subject);
+    }
 
     public void closeTeam(Boolean isClosed) {
         if (this.isClosed) {
@@ -34,5 +48,24 @@ public class Team extends BaseEntity {
         }
 
         this.isClosed = isClosed;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Team team = (Team) o;
+        return Objects.equals(id, team.id) && Objects.equals(name, team.name)
+            && Objects.equals(subject, team.subject) && Objects.equals(isClosed,
+            team.isClosed) && Objects.equals(teamMemberList, team.teamMemberList);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, subject, isClosed, teamMemberList);
     }
 }

--- a/src/main/java/kappzzang/jeongsan/domain/Team.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Team.java
@@ -38,8 +38,22 @@ public class Team extends BaseEntity {
         teamMemberList = new ArrayList<>();
     }
 
-    public static Team createTeam(String name, String subject) {
-        return new Team(name, subject);
+    public static Team createTeam(Member owner, String name, String subject, List<Member> members) {
+        Team team = new Team(name, subject);
+        team.addMember(owner, true, true);
+        team.addMember(members);
+        return team;
+    }
+
+    public void addMember(Member member, Boolean isOwner, Boolean isInviteAccepted) {
+        TeamMember teamMember = new TeamMember(member, this, isOwner, isInviteAccepted);
+        teamMemberList.add(teamMember);
+    }
+
+    public void addMember(List<Member> members) {
+        for (Member member : members) {
+            addMember(member, false, false);
+        }
     }
 
     public void closeTeam(Boolean isClosed) {

--- a/src/main/java/kappzzang/jeongsan/dto/request/CreateTeamRequest.java
+++ b/src/main/java/kappzzang/jeongsan/dto/request/CreateTeamRequest.java
@@ -11,6 +11,7 @@ public record CreateTeamRequest(
     String name,
     @NotNull
     String subject,
+    @NotNull
     List<Long> members
 ) {
 

--- a/src/main/java/kappzzang/jeongsan/dto/request/CreateTeamRequest.java
+++ b/src/main/java/kappzzang/jeongsan/dto/request/CreateTeamRequest.java
@@ -1,11 +1,12 @@
 package kappzzang.jeongsan.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record CreateTeamRequest(
-    @NotNull
+    @NotBlank
     @Size(min = 1, max = 15)
     String name,
     @NotNull

--- a/src/main/java/kappzzang/jeongsan/dto/request/CreateTeamRequest.java
+++ b/src/main/java/kappzzang/jeongsan/dto/request/CreateTeamRequest.java
@@ -1,0 +1,16 @@
+package kappzzang.jeongsan.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record CreateTeamRequest(
+    @NotNull
+    @Size(min = 1, max = 15)
+    String name,
+    @NotNull
+    String subject,
+    List<Long> members
+) {
+
+}

--- a/src/main/java/kappzzang/jeongsan/dto/response/CreateTeamResponse.java
+++ b/src/main/java/kappzzang/jeongsan/dto/response/CreateTeamResponse.java
@@ -1,0 +1,5 @@
+package kappzzang.jeongsan.dto.response;
+
+public record CreateTeamResponse(Long teamId) {
+
+}

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
@@ -31,6 +31,9 @@ public enum ErrorType {
     //408 REQUEST_TIMEOUT
     EXTERNAL_API_REQUEST_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "E408001", "외부 API 요청 시간이 초과되었습니다."),
 
+    //409 CONFLICT
+    TEAM_NAME_DUPLICATED(HttpStatus.CONFLICT, "E409", "중복된 모임 이름이 존재합니다."),
+
     // 500 INTERNAL_SERVER_ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E500001", "서버 내부 오류가 발생했습니다."),
     RECEIPT_EXTRACTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "E500002", "영수증 데이터 추출에 실패했습니다."),

--- a/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import kappzzang.jeongsan.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
 
@@ -12,4 +13,10 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
         "JOIN FETCH tm.member " +
         "WHERE t.isClosed = :isClosed")
     List<Team> findByIsClosed(Boolean isClosed);
+
+    @Query("SELECT CASE WHEN COUNT(t) > 0 THEN TRUE ELSE FALSE END "
+        + "FROM Team t "
+        + "JOIN TeamMember tm ON t.id = tm.team.id "
+        + "WHERE t.name = :name AND tm.member.id = :memberId")
+    Boolean existsByNameAndMemberId(@Param("name") String name, @Param("memberId") Long memberId);
 }

--- a/src/main/java/kappzzang/jeongsan/service/TeamService.java
+++ b/src/main/java/kappzzang/jeongsan/service/TeamService.java
@@ -1,5 +1,6 @@
 package kappzzang.jeongsan.service;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import kappzzang.jeongsan.domain.Member;
@@ -43,10 +44,13 @@ public class TeamService {
         Member owner = memberRepository.findById(memberId)
             .orElseThrow(() -> new JeongsanException(ErrorType.USER_NOT_FOUND));
 
-        List<Member> members = request.members().stream()
+        List<Member> members = Collections.emptyList();
+        if(!request.members().isEmpty()) {
+            members = request.members().stream()
             .map(id -> memberRepository.findById(id)
                 .orElseThrow(() -> new JeongsanException(ErrorType.USER_NOT_FOUND)))
             .toList();
+        }
 
         Team team = Team.createTeam(owner, request.name(), request.subject(), members);
 

--- a/src/main/java/kappzzang/jeongsan/service/TeamService.java
+++ b/src/main/java/kappzzang/jeongsan/service/TeamService.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 import kappzzang.jeongsan.domain.Team;
 import kappzzang.jeongsan.dto.request.CloseTeamRequest;
+import kappzzang.jeongsan.dto.request.CreateTeamRequest;
+import kappzzang.jeongsan.dto.response.CreateTeamResponse;
 import kappzzang.jeongsan.dto.response.InvitationStatusResponse;
 import kappzzang.jeongsan.dto.response.TeamResponse;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
@@ -27,6 +29,17 @@ public class TeamService {
             .stream()
             .map(TeamResponse::from)
             .toList();
+    }
+
+    @Transactional
+    public CreateTeamResponse createTeam(Long memberId, CreateTeamRequest request) {
+        if(teamRepository.existsByNameAndMemberId(request.name(), memberId)) {
+            throw new JeongsanException(ErrorType.TEAM_NAME_DUPLICATED);
+        }
+
+        Team team = Team.createTeam(request.name(), request.subject());
+
+        return new CreateTeamResponse(teamRepository.save(team).getId());
     }
 
     @Transactional

--- a/src/main/java/kappzzang/jeongsan/service/TeamService.java
+++ b/src/main/java/kappzzang/jeongsan/service/TeamService.java
@@ -37,6 +37,7 @@ public class TeamService {
             throw new JeongsanException(ErrorType.TEAM_NAME_DUPLICATED);
         }
 
+        // TODO: 모임 멤버 추가 도메인 메서드 구현에 따른 리팩토링 필요
         Team team = Team.createTeam(request.name(), request.subject());
 
         return new CreateTeamResponse(teamRepository.save(team).getId());

--- a/src/test/java/kappzzang/jeongsan/service/TeamServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/TeamServiceTest.java
@@ -4,11 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import kappzzang.jeongsan.domain.Team;
+import kappzzang.jeongsan.dto.request.CreateTeamRequest;
+import kappzzang.jeongsan.dto.response.CreateTeamResponse;
 import kappzzang.jeongsan.dto.response.InvitationStatusResponse;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
 import kappzzang.jeongsan.global.exception.JeongsanException;
@@ -49,7 +53,8 @@ class TeamServiceTest {
         // given
         Long teamId = 1L;
         given(teamRepository.findById(teamId)).willReturn(Optional.of(new Team()));
-        given(teamMemberRepository.findInvitationStatusByTeamId(teamId)).willReturn(Collections.emptyList());
+        given(teamMemberRepository.findInvitationStatusByTeamId(teamId)).willReturn(
+            Collections.emptyList());
 
         // when & then
         assertThatThrownBy(() -> teamService.getInvitationStatus(1L))
@@ -80,5 +85,41 @@ class TeamServiceTest {
                 assertThat(response.profileImage()).isEqualTo("profileImage");
                 assertThat(response.isInviteAccepted()).isFalse();
             });
+    }
+
+    @Test
+    @DisplayName("모임 생성자에게 동일한 모임 이름이 존재")
+    void createTeam_NameDuplicateException() {
+        // given
+        Long memberId = 1L;
+        String teamName = "Test Team";
+        given(teamRepository.existsByNameAndMemberId(teamName, memberId)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() ->
+            teamService.createTeam(memberId,
+                new CreateTeamRequest(teamName, "subject", new ArrayList<>()))
+        ).isInstanceOf(JeongsanException.class);
+        then(teamRepository).should().existsByNameAndMemberId(teamName, memberId);
+    }
+
+    @Test
+    @DisplayName("모임 생성 성공")
+    void createTeam_Success() {
+        // given
+        Long memberId = 1L;
+        String teamName = "Test Team";
+        CreateTeamRequest request = new CreateTeamRequest(teamName, "subject", new ArrayList<>());
+        Team team = new Team(teamName, "subject");
+        given(teamRepository.existsByNameAndMemberId(teamName, memberId)).willReturn(false);
+        given(teamRepository.save(team)).willReturn(new Team(teamName, "subject"));
+
+        // when
+        CreateTeamResponse actual = teamService.createTeam(memberId, request);
+
+        // then
+        assertThat(actual).isNotNull();
+        then(teamRepository).should().existsByNameAndMemberId(teamName, memberId);
+        then(teamRepository).should().save(team);
     }
 }


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 모임 생성 기능을 구현했습니다
- 카톡에 남겼던대로 각 `members`로 요청되는 사람들은 `isInviteAccepted = false`로 TeamMember에 저장합니다
- 요청을 보낸 사람은 `isInviteAccepted = true`로 TeamMember에 저장합니다


### 🔍 참고 사항
- #66 과 충돌이 발생할 여지가 있습니다. #66 이 먼저 병합된다면 충돌을 해결하고 다시 커밋하겠습니다

### ⚠️ 의논 필요
- 모임 이름 중복에 대해 생각해볼 여지가 있습니다
  1. owner 중심으로 owner가 가진 모임 이름만 중복 불허 <- 현재 적용
  2. 모든 team member 중심으로 전수검사 - 이 경우 모임 중간에 새 인원을 축가할 때 오류가 발생할 여지가 있습니다
  3. 중복 상관없이 전체 허용

### 🐞현재 버그
- 에러 발생은 application.properties가 현재 git에 적용된 버전은 준석님이 jwt 관련 설정을 바꾼 것이고, 작업된 소스코드는 바꾸기 전 기준으로 작성되어 JwtUtil 부분에서 오류가 발생한 것으로 추정됩니다

### #️⃣ 연관 이슈(Git Close)
- close #67 
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
