### PR TITLE
Refactor/issue#74: Item, PersonalExpense 엔티티 연관관계 수정

### DIFF
--- a/src/main/java/kappzzang/jeongsan/domain/Item.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Item.java
@@ -6,9 +6,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,9 +28,6 @@ public class Item {
     private Integer unitPrice;
     private Integer totalPrice;
 
-    @OneToMany(mappedBy = "item")
-    private final List<PersonalExpense> personalExpenses = new ArrayList<>();
-
     @Builder
     public Item(String name, Integer quantity, Integer unitPrice) {
         this.name = name;
@@ -48,11 +42,6 @@ public class Item {
 
     public void calculateTotalPrice() {
         this.totalPrice = quantity * unitPrice;
-    }
-
-    public void addPersonalExpense(PersonalExpense personalExpense) {
-        this.personalExpenses.add(personalExpense);
-        personalExpense.assignItem(this);
     }
 
 }

--- a/src/test/java/kappzzang/jeongsan/repository/ExpenseRepositoryTest.java
+++ b/src/test/java/kappzzang/jeongsan/repository/ExpenseRepositoryTest.java
@@ -59,10 +59,11 @@ public class ExpenseRepositoryTest {
         Item itemC = testDataUtil.createAndPersistItem("TEST_ITEM_C", 15, 4000);
         Item itemD = testDataUtil.createAndPersistItem("TEST_ITEM_D", 3, 1000);
 
-        itemA.addPersonalExpense(personalExpenseA);
-        itemB.addPersonalExpense(personalExpenseB);
-        itemC.addPersonalExpense(personalExpenseC);
-        itemD.addPersonalExpense(personalExpenseD);
+        personalExpenseA.assignItem(itemA);
+        personalExpenseB.assignItem(itemB);
+        personalExpenseC.assignItem(itemC);
+        personalExpenseD.assignItem(itemD);
+
 
         List<Item> items = List.of(itemA, itemB, itemC, itemD);
         Category category = testDataUtil.createAndPersistCategory();

--- a/src/test/java/kappzzang/jeongsan/repository/ExpenseRepositoryTest.java
+++ b/src/test/java/kappzzang/jeongsan/repository/ExpenseRepositoryTest.java
@@ -64,7 +64,6 @@ public class ExpenseRepositoryTest {
         personalExpenseC.assignItem(itemC);
         personalExpenseD.assignItem(itemD);
 
-
         List<Item> items = List.of(itemA, itemB, itemC, itemD);
         Category category = testDataUtil.createAndPersistCategory();
 


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- `Item`엔티티에서 `PersonalExpense`로의 매핑 제거

### 🔍 참고 사항
- 10/14 회의 내용에 따라 `item`엔티티의 `PersonalExpense`필드를 삭제하였습니다.

### ⚠️ 의논 필요
- X

### 🐞현재 버그
- X

### #️⃣ 연관 이슈(Git Close)
- #74 
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
