### PR TITLE
Refactor/issue#77: TestUtil 및 주석 처리된 레포지토리 테스트 코드 수정

### DIFF
--- a/src/main/java/kappzzang/jeongsan/domain/Category.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Category.java
@@ -22,4 +22,9 @@ public class Category {
 
     @Column(nullable = false)
     private String color;
+
+    public Category(String name, String color) {
+        this.name = name;
+        this.color = color;
+    }
 }

--- a/src/main/java/kappzzang/jeongsan/domain/PersonalExpense.java
+++ b/src/main/java/kappzzang/jeongsan/domain/PersonalExpense.java
@@ -38,12 +38,9 @@ public class PersonalExpense extends BaseEntity {
     private Integer totalPrice;
 
     @Builder
-    public PersonalExpense(Member member, Integer quantity) {
+    public PersonalExpense(Member member, Integer quantity, Item item) {
         this.member = member;
         this.quantity = quantity;
-    }
-
-    public void assignItem(Item item) {
         this.item = item;
         calculateConsumedItemTotalPrice();
     }

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
@@ -25,7 +25,6 @@ public enum ErrorType {
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "E404002", "모임을 찾을 수 없습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "E404003", "카테고리을 찾을 수 없습니다."),
     EXPENSE_NOT_FOUND(HttpStatus.NOT_FOUND, "E404004", "지출을 찾을 수 없습니다."),
-    PERSONAL_EXPENSE_NOT_FOUND(HttpStatus.NOT_FOUND, "E404005", "개인 지출을 찾을 수 없습니다."),
     INVITATION_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "E404006", "초대 현황을 찾을 수 없습니다."),
 
     //408 REQUEST_TIMEOUT

--- a/src/test/java/kappzzang/jeongsan/repository/ExpenseRepositoryTest.java
+++ b/src/test/java/kappzzang/jeongsan/repository/ExpenseRepositoryTest.java
@@ -1,110 +1,108 @@
-//package kappzzang.jeongsan.repository;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//
-//import java.util.List;
-//import java.util.stream.Stream;
-//import kappzzang.jeongsan.domain.Category;
-//import kappzzang.jeongsan.domain.Expense;
-//import kappzzang.jeongsan.domain.Item;
-//import kappzzang.jeongsan.domain.KakaoPayInfo;
-//import kappzzang.jeongsan.domain.Member;
-//import kappzzang.jeongsan.domain.PersonalExpense;
-//import kappzzang.jeongsan.domain.Team;
-//import kappzzang.jeongsan.dto.ItemDetail;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.params.ParameterizedTest;
-//import org.junit.jupiter.params.provider.Arguments;
-//import org.junit.jupiter.params.provider.MethodSource;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-//import org.springframework.context.annotation.Import;
-//
-//@DataJpaTest
-//@Import(TestDataUtil.class)
-//public class ExpenseRepositoryTest {
-//
-//    private static final Integer TEST_ITEM_QUANTITY = 4;
-//
-//    @Autowired
-//    private ExpenseRepository expenseRepository;
-//
-//    @Autowired
-//    private TestDataUtil testDataUtil;
-//
-//    private Expense expense;
-//    private List<Member> members;
-//
-//    @BeforeEach
-//    void setUp() {
-//        KakaoPayInfo kakaoPayInfo = testDataUtil.createAndPersistKakaoPayInfo();
-//
-//        Member memberA = testDataUtil.createAndPersistMember("TEST_USER_A", kakaoPayInfo);
-//        Member memberB = testDataUtil.createAndPersistMember("TEST_USER_B", kakaoPayInfo);
-//        Member memberC = testDataUtil.createAndPersistMember("TEST_USER_C", kakaoPayInfo);
-//        members = List.of(memberA, memberB, memberC);
-//
-//        Team team = testDataUtil.createAndPersistTeam();
-//
-//        PersonalExpense personalExpenseA = testDataUtil.createAndPersistPersonalExpense(memberA, 5);
-//
-//        PersonalExpense personalExpenseB = testDataUtil.createAndPersistPersonalExpense(memberB, 3);
-//        PersonalExpense personalExpenseC = testDataUtil.createAndPersistPersonalExpense(memberB, 9);
-//        PersonalExpense personalExpenseD = testDataUtil.createAndPersistPersonalExpense(memberB,
-//            10);
-//
-//        Item itemA = testDataUtil.createAndPersistItem("TEST_ITEM_A", 10, 2000);
-//        Item itemB = testDataUtil.createAndPersistItem("TEST_ITEM_B", 5, 3000);
-//        Item itemC = testDataUtil.createAndPersistItem("TEST_ITEM_C", 15, 4000);
-//        Item itemD = testDataUtil.createAndPersistItem("TEST_ITEM_D", 3, 1000);
-//
-//        itemA.addPersonalExpense(personalExpenseA);
-//        itemB.addPersonalExpense(personalExpenseB);
-//        itemC.addPersonalExpense(personalExpenseC);
-//        itemD.addPersonalExpense(personalExpenseD);
-//
-//        List<Item> items = List.of(itemA, itemB, itemC, itemD);
-//        Category category = testDataUtil.createAndPersistCategory();
-//
-//        expense = testDataUtil.createAndPersistExpense(team, memberA, category, items);
-//    }
-//
-//    @MethodSource("PersonalExpenseCaseProvider")
-//    @ParameterizedTest(name = "memberOrder: {0}")
-//    @DisplayName("맴버 별 지출 상세 조회 테스트(PersonalExpense 미등록 품목 포함)")
-//    void testFindItemDetailsByExpenseIdAndMemberId(Integer memberOrder, List<?> expectedQuantity) {
-//        //given
-//        final String DEFAULT_TEST_FILED = "consumedQuantity";
-//        Long expenseId = expense.getId();
-//        Long memberId = members.get(memberOrder).getId();
-//
-//        //when
-//        List<ItemDetail> actual = expenseRepository.findItemDetailsByExpenseIdAndMemberId(expenseId,
-//            memberId);
-//
-//        //then
-//        assertThat(actual)
-//            .isNotNull()
-//            .hasSize(TEST_ITEM_QUANTITY)
-//            .satisfies(expected -> {
-//                for (int i = 0; i < TEST_ITEM_QUANTITY; i++) {
-//                    assertThat(actual.get(i)).hasFieldOrPropertyWithValue(DEFAULT_TEST_FILED,
-//                        expectedQuantity.get(i));
-//                }
-//            });
-//    }
-//
-//    static Stream<Arguments> PersonalExpenseCaseProvider() {
-//        return Stream.of(
-//            Arguments.of(0, List.of(5, 0, 0, 0)),
-//            //0번째 맴버가 선택한 지출(itemA: 5, itemB: 0, itemC: 0, itemD: 0)
-//            Arguments.of(1, List.of(0, 3, 9, 10)),
-//            //1번째 맴버가 선택한 지출(itemA: 0, itemB: 3, itemC: 9, itemD: 10)
-//            Arguments.of(2, List.of(0, 0, 0, 0))
-//            //2번째 맴버가 선택한 지출(itemA: 0, itemB: 0, itemC: 0, itemD: 0)
-//        );
-//    }
-//
-//}
-//
+package kappzzang.jeongsan.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Stream;
+import kappzzang.jeongsan.domain.Category;
+import kappzzang.jeongsan.domain.Expense;
+import kappzzang.jeongsan.domain.Item;
+import kappzzang.jeongsan.domain.KakaoPayInfo;
+import kappzzang.jeongsan.domain.Member;
+import kappzzang.jeongsan.domain.PersonalExpense;
+import kappzzang.jeongsan.domain.Team;
+import kappzzang.jeongsan.dto.ItemDetail;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(TestDataUtil.class)
+public class ExpenseRepositoryTest {
+
+    private static final Integer TEST_ITEM_QUANTITY = 4;
+
+    @Autowired
+    private ExpenseRepository expenseRepository;
+
+    @Autowired
+    private TestDataUtil testDataUtil;
+
+    private Expense expense;
+    private List<Member> members;
+
+    @BeforeEach
+    void setUp() {
+        KakaoPayInfo kakaoPayInfo = new KakaoPayInfo();
+
+        Member memberA = testDataUtil.createAndPersistMember("TEST_USER_A", kakaoPayInfo);
+        Member memberB = testDataUtil.createAndPersistMember("TEST_USER_B", kakaoPayInfo);
+        Member memberC = testDataUtil.createAndPersistMember("TEST_USER_C", kakaoPayInfo);
+        members = List.of(memberA, memberB, memberC);
+
+        Team team = testDataUtil.createAndPersistTeam();
+
+        Item itemA = testDataUtil.createAndPersistItem("TEST_ITEM_A", 10, 2000);
+        Item itemB = testDataUtil.createAndPersistItem("TEST_ITEM_B", 5, 3000);
+        Item itemC = testDataUtil.createAndPersistItem("TEST_ITEM_C", 15, 4000);
+        Item itemD = testDataUtil.createAndPersistItem("TEST_ITEM_D", 3, 1000);
+
+        PersonalExpense personalExpenseA = testDataUtil.createAndPersistPersonalExpense(memberA, 5,
+            itemA);
+
+        PersonalExpense personalExpenseB = testDataUtil.createAndPersistPersonalExpense(memberB, 3,
+            itemB);
+        PersonalExpense personalExpenseC = testDataUtil.createAndPersistPersonalExpense(memberB, 9,
+            itemC);
+        PersonalExpense personalExpenseD = testDataUtil.createAndPersistPersonalExpense(memberB,
+            10, itemD);
+
+        List<Item> items = List.of(itemA, itemB, itemC, itemD);
+        Category category = testDataUtil.createAndPersistCategory();
+
+        expense = testDataUtil.createAndPersistExpense(team, memberA, category, items);
+    }
+
+    @MethodSource("PersonalExpenseCaseProvider")
+    @ParameterizedTest(name = "memberOrder: {0}")
+    @DisplayName("맴버 별 지출 상세 조회 테스트(PersonalExpense 미등록 품목 포함)")
+    void testFindItemDetailsByExpenseIdAndMemberId(Integer memberOrder, List<?> expectedQuantity) {
+        //given
+        final String DEFAULT_TEST_FILED = "consumedQuantity";
+        Long expenseId = expense.getId();
+        Long memberId = members.get(memberOrder).getId();
+
+        //when
+        List<ItemDetail> actual = expenseRepository.findItemDetailsByExpenseIdAndMemberId(expenseId,
+            memberId);
+
+        //then
+        assertThat(actual)
+            .isNotNull()
+            .hasSize(TEST_ITEM_QUANTITY)
+            .satisfies(expected -> {
+                for (int i = 0; i < TEST_ITEM_QUANTITY; i++) {
+                    assertThat(actual.get(i)).hasFieldOrPropertyWithValue(DEFAULT_TEST_FILED,
+                        expectedQuantity.get(i));
+                }
+            });
+    }
+
+    static Stream<Arguments> PersonalExpenseCaseProvider() {
+        return Stream.of(
+            Arguments.of(0, List.of(5, 0, 0, 0)),
+            //0번째 맴버가 선택한 지출(itemA: 5, itemB: 0, itemC: 0, itemD: 0)
+            Arguments.of(1, List.of(0, 3, 9, 10)),
+            //1번째 맴버가 선택한 지출(itemA: 0, itemB: 3, itemC: 9, itemD: 10)
+            Arguments.of(2, List.of(0, 0, 0, 0))
+            //2번째 맴버가 선택한 지출(itemA: 0, itemB: 0, itemC: 0, itemD: 0)
+        );
+    }
+
+}
+

--- a/src/test/java/kappzzang/jeongsan/repository/TeamMemberRepositoryTest.java
+++ b/src/test/java/kappzzang/jeongsan/repository/TeamMemberRepositoryTest.java
@@ -1,66 +1,66 @@
-//package kappzzang.jeongsan.repository;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//
-//import java.util.List;
-//import kappzzang.jeongsan.domain.KakaoPayInfo;
-//import kappzzang.jeongsan.domain.Member;
-//import kappzzang.jeongsan.domain.Team;
-//import kappzzang.jeongsan.dto.response.InvitationStatusResponse;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-//import org.springframework.context.annotation.Import;
-//
-//@DataJpaTest
-//@Import(TestDataUtil.class)
-//class TeamMemberRepositoryTest {
-//
-//    @Autowired
-//    private TestDataUtil testDataUtil;
-//    @Autowired
-//    private TeamMemberRepository teamMemberRepository;
-//
-//    private Team team;
-//    private Member member1;
-//    private Member member2;
-//
-//    @BeforeEach
-//    void setUp() {
-//        // given
-//        team = testDataUtil.createAndPersistTeam();
-//
-//        KakaoPayInfo kakaoPayInfo = testDataUtil.createAndPersistKakaoPayInfo();
-//
-//        member1 = testDataUtil.createAndPersistMember("nickname1", kakaoPayInfo);
-//        member2 = testDataUtil.createAndPersistMember("nickname2", kakaoPayInfo);
-//
-//        testDataUtil.createAndPersistTeamMember(member1, team, true, true);
-//        testDataUtil.createAndPersistTeamMember(member2, team, false, false);
-//    }
-//
-//    @Test
-//    @DisplayName("모임의 멤버 초대 현황 조회 - 레포지토리 테스트")
-//    void findInvitationStatusByTeamId() {
-//        // when
-//        List<InvitationStatusResponse> result = teamMemberRepository.findInvitationStatusByTeamId(
-//            team.getId());
-//
-//        // then
-//        assertThat(result).hasSize(2);
-//
-//        assertThat(result).anySatisfy(response -> {
-//            assertThat(response.memberId()).isEqualTo(member1.getId());
-//            assertThat(response.nickname()).isEqualTo("nickname1");
-//            assertThat(response.isInviteAccepted()).isTrue();
-//        });
-//
-//        assertThat(result).anySatisfy(response -> {
-//            assertThat(response.memberId()).isEqualTo(member2.getId());
-//            assertThat(response.nickname()).isEqualTo("nickname2");
-//            assertThat(response.isInviteAccepted()).isFalse();
-//        });
-//    }
-//}
+package kappzzang.jeongsan.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import kappzzang.jeongsan.domain.KakaoPayInfo;
+import kappzzang.jeongsan.domain.Member;
+import kappzzang.jeongsan.domain.Team;
+import kappzzang.jeongsan.dto.response.InvitationStatusResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(TestDataUtil.class)
+class TeamMemberRepositoryTest {
+
+    @Autowired
+    private TestDataUtil testDataUtil;
+    @Autowired
+    private TeamMemberRepository teamMemberRepository;
+
+    private Team team;
+    private Member member1;
+    private Member member2;
+
+    @BeforeEach
+    void setUp() {
+        // given
+        team = testDataUtil.createAndPersistTeam();
+
+        KakaoPayInfo kakaoPayInfo = new KakaoPayInfo();
+
+        member1 = testDataUtil.createAndPersistMember("nickname1", kakaoPayInfo);
+        member2 = testDataUtil.createAndPersistMember("nickname2", kakaoPayInfo);
+
+        testDataUtil.createAndPersistTeamMember(member1, team, true, true);
+        testDataUtil.createAndPersistTeamMember(member2, team, false, false);
+    }
+
+    @Test
+    @DisplayName("모임의 멤버 초대 현황 조회 - 레포지토리 테스트")
+    void findInvitationStatusByTeamId() {
+        // when
+        List<InvitationStatusResponse> result = teamMemberRepository.findInvitationStatusByTeamId(
+            team.getId());
+
+        // then
+        assertThat(result).hasSize(2);
+
+        assertThat(result).anySatisfy(response -> {
+            assertThat(response.memberId()).isEqualTo(member1.getId());
+            assertThat(response.nickname()).isEqualTo("nickname1");
+            assertThat(response.isInviteAccepted()).isTrue();
+        });
+
+        assertThat(result).anySatisfy(response -> {
+            assertThat(response.memberId()).isEqualTo(member2.getId());
+            assertThat(response.nickname()).isEqualTo("nickname2");
+            assertThat(response.isInviteAccepted()).isFalse();
+        });
+    }
+}

--- a/src/test/java/kappzzang/jeongsan/repository/TestDataUtil.java
+++ b/src/test/java/kappzzang/jeongsan/repository/TestDataUtil.java
@@ -1,106 +1,108 @@
-//package kappzzang.jeongsan.repository;
-//
-//import java.time.LocalDateTime;
-//import java.util.List;
-//import kappzzang.jeongsan.domain.Category;
-//import kappzzang.jeongsan.domain.Expense;
-//import kappzzang.jeongsan.domain.Item;
-//import kappzzang.jeongsan.domain.KakaoPayInfo;
-//import kappzzang.jeongsan.domain.Member;
-//import kappzzang.jeongsan.domain.PersonalExpense;
-//import kappzzang.jeongsan.domain.Team;
-//import kappzzang.jeongsan.domain.TeamMember;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-//import org.springframework.boot.test.context.TestComponent;
-//
-//@TestComponent
-//public class TestDataUtil {
-//
-//    private static final String DEFAULT_KAKAO_ID = "DEFAULT_KAKAO_ID";
-//    private static final String DEFAULT_NAME = "DEFAULT_NAME";
-//    private static final String DEFAULT_EMAIL = "DEFAULT_EMAIL";
-//    private static final String DEFAULT_URL = "DEFAULT_URL";
-//
-//    private final TestEntityManager entityManager;
-//
-//    @Autowired
-//    public TestDataUtil(TestEntityManager entityManager) {
-//        this.entityManager = entityManager;
-//    }
-//
-//    //생성 방식 확정 이후 리펙토링 필요
-//    public Team createAndPersistTeam() {
-//        Team team = new Team();
-//        entityManager.persist(team);
-//        return team;
-//    }
-//
-//    //생성 방식 확정 이후 리펙토링 필요
-//    public KakaoPayInfo createAndPersistKakaoPayInfo() {
-//        KakaoPayInfo kakaoPayInfo = new KakaoPayInfo();
-//        entityManager.persist(kakaoPayInfo);
-//        return kakaoPayInfo;
-//    }
-//
-//    public Category createAndPersistCategory() {
-//        Category category = new Category();
-//        entityManager.persist(category);
-//        return category;
-//    }
-//
-//    public Member createAndPersistMember(String nickname, KakaoPayInfo kakaoToken) {
-//        Member member = Member.builder()
-//            .kakaoId(DEFAULT_KAKAO_ID)
-//            .email(DEFAULT_EMAIL)
-//            .nickname(nickname)
-//            .profileImage(DEFAULT_URL)
-//            .kakaoPayInfo(kakaoToken)
-//            .build();
-//        entityManager.persist(member);
-//        return member;
-//    }
-//
-//    public Expense createAndPersistExpense(Team team, Member payer, Category category,
-//        List<Item> items) {
-//        Expense expense = Expense.builder()
-//            .team(team)
-//            .member(payer)
-//            .title(DEFAULT_NAME)
-//            .category(category)
-//            .paymentTime(LocalDateTime.now())
-//            .imageUrl(DEFAULT_URL)
-//            .items(items)
-//            .build();
-//        entityManager.persist(expense);
-//        return expense;
-//    }
-//
-//    public PersonalExpense createAndPersistPersonalExpense(Member member,
-//        Integer consumedQuantity) {
-//        PersonalExpense personalExpense = PersonalExpense.builder()
-//            .member(member)
-//            .quantity(consumedQuantity)
-//            .build();
-//        entityManager.persist(personalExpense);
-//        return personalExpense;
-//    }
-//
-//    public Item createAndPersistItem(String name, Integer price, Integer quantity) {
-//        Item item = new Item(name, price, quantity);
-//        entityManager.persist(item);
-//        return item;
-//    }
-//
-//    public TeamMember createAndPersistTeamMember(Member member, Team team, Boolean isOwner,
-//        Boolean isInviteAccepted) {
-//        TeamMember teamMember = new TeamMember(member, team, isOwner, isInviteAccepted);
-//        entityManager.persist(teamMember);
-//        return teamMember;
-//    }
-//
-//    public void commit() {
-//        entityManager.flush();
-//    }
-//
-//}
+package kappzzang.jeongsan.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import kappzzang.jeongsan.domain.Category;
+import kappzzang.jeongsan.domain.Expense;
+import kappzzang.jeongsan.domain.Item;
+import kappzzang.jeongsan.domain.KakaoPayInfo;
+import kappzzang.jeongsan.domain.Member;
+import kappzzang.jeongsan.domain.PersonalExpense;
+import kappzzang.jeongsan.domain.Team;
+import kappzzang.jeongsan.domain.TeamMember;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestComponent;
+
+@TestComponent
+public class TestDataUtil {
+
+    private static final String DEFAULT_KAKAO_ID = "DEFAULT_KAKAO_ID";
+    private static final String DEFAULT_NAME = "DEFAULT_NAME";
+    private static final String DEFAULT_COLOR = "DEFAULT_COLOR";
+    private static final String DEFAULT_SUBJECT = "DEFAULT_SUBJECT";
+    private static final String DEFAULT_EMAIL = "DEFAULT_EMAIL";
+    private static final String DEFAULT_URL = "DEFAULT_URL";
+
+    private final TestEntityManager entityManager;
+
+    @Autowired
+    public TestDataUtil(TestEntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    //Team
+    public Team createAndPersistTeam() {
+        Team team = new Team(DEFAULT_NAME, DEFAULT_SUBJECT);
+        entityManager.persist(team);
+        return team;
+    }
+
+    //Category
+    public Category createAndPersistCategory() {
+        Category category = new Category(DEFAULT_NAME, DEFAULT_COLOR);
+        entityManager.persist(category);
+        return category;
+    }
+
+    //Member
+    public Member createAndPersistMember(String nickname, KakaoPayInfo kakaoPayInfo) {
+        Member member = Member.builder()
+            .kakaoId(DEFAULT_KAKAO_ID)
+            .email(DEFAULT_EMAIL)
+            .nickname(nickname)
+            .profileImage(DEFAULT_URL)
+            .kakaoPayInfo(kakaoPayInfo)
+            .build();
+        entityManager.persist(member);
+        return member;
+    }
+
+    //Expense
+    public Expense createAndPersistExpense(Team team, Member payer, Category category,
+        List<Item> items) {
+        Expense expense = Expense.builder()
+            .team(team)
+            .member(payer)
+            .title(DEFAULT_NAME)
+            .category(category)
+            .paymentTime(LocalDateTime.now())
+            .imageUrl(DEFAULT_URL)
+            .items(items)
+            .build();
+        entityManager.persist(expense);
+        return expense;
+    }
+
+    //PersonalExpense
+    public PersonalExpense createAndPersistPersonalExpense(Member member,
+        Integer consumedQuantity, Item item) {
+        PersonalExpense personalExpense = PersonalExpense.builder()
+            .member(member)
+            .quantity(consumedQuantity)
+            .item(item)
+            .build();
+        entityManager.persist(personalExpense);
+        return personalExpense;
+    }
+
+    //Item
+    public Item createAndPersistItem(String name, Integer price, Integer quantity) {
+        Item item = new Item(name, price, quantity);
+        entityManager.persist(item);
+        return item;
+    }
+
+    //TeamMember
+    public TeamMember createAndPersistTeamMember(Member member, Team team, Boolean isOwner,
+        Boolean isInviteAccepted) {
+        TeamMember teamMember = new TeamMember(member, team, isOwner, isInviteAccepted);
+        entityManager.persist(teamMember);
+        return teamMember;
+    }
+
+    public void commit() {
+        entityManager.flush();
+    }
+
+}


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- Category, PersonalExpense 엔티티 생성자 추가 및 수정
- TestDataUtil, RepositoryTest 수정
- 사용되지 않는 에러 코드 삭제

### 🔍 참고 사항
- #76 에서 엔티티 제약 조건 추가로 주석 처리된 테스트 코드 수정하였습니다.
- `TestDataUtil`의 주석의 경우 각 도메인 별 오버로딩 되는 메서드 추가(**테스트 시 기본 값이 아닌 인자로 생성해야 할 경우**)를 고려하여 작성하였습니다.
- `PERSONAL_EXPENSE_NOT_FOUND`는 사용되지 않아 제거하였고 그에 따라 `E404006` 번호가 당겨져야 합니다.

### ⚠️ 의논 필요
- X

### 🐞현재 버그
- X

### #️⃣ 연관 이슈(Git Close)
- close #77 
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
