### PR TITLE
Refactor/issue#63: ExpenseSerivce 테스트 코드 추가 및 예외 처리 추가

### DIFF
--- a/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
@@ -10,6 +10,7 @@ import kappzzang.jeongsan.global.exception.JeongsanException;
 import kappzzang.jeongsan.service.ExpenseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,6 +27,7 @@ public class ExpenseController implements ExpenseControllerInterface {
     @Override
     @GetMapping("{teamId}")
     public ResponseEntity<JeongsanApiResponse<ExpenseResponse>> getAllExpenses(
+        @AuthenticationPrincipal Long memberId,
         @PathVariable Long teamId,
         @RequestParam String state,
         @RequestParam(required = false) Boolean isChecked) {
@@ -41,6 +43,6 @@ public class ExpenseController implements ExpenseControllerInterface {
         }
 
         return JeongsanApiResponse.success(SuccessType.EXPENSE_LIST_LOADED,
-            expenseService.getExpenses(1L, teamId, status, isChecked));
+            expenseService.getExpenses(memberId, teamId, status, isChecked));
     }
 }

--- a/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
@@ -41,6 +41,6 @@ public class ExpenseController implements ExpenseControllerInterface {
         }
 
         return JeongsanApiResponse.success(SuccessType.EXPENSE_LIST_LOADED,
-            expenseService.getResponses(1L, teamId, status, isChecked));
+            expenseService.getExpenses(1L, teamId, status, isChecked));
     }
 }

--- a/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
@@ -28,6 +28,6 @@ public interface ExpenseControllerInterface {
         @ApiResponse(responseCode = "400", description = "`state`에 잘못된 값 입력. `ongoing`, `pending`, `completed`만 가능 (ErrorCode-E400003)"),
         @ApiResponse(responseCode = "404", description = "`teamId`에 해당하는 모임이 존재하지 않음. (ErrorCode-E404002)")
     })
-    ResponseEntity<JeongsanApiResponse<ExpenseResponse>> getAllExpenses(Long teamId, String state,
-        Boolean isChecked);
+    ResponseEntity<JeongsanApiResponse<ExpenseResponse>> getAllExpenses(Long memberId, Long teamId,
+        String state, Boolean isChecked);
 }

--- a/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
@@ -56,7 +56,7 @@ public class ExpenseService {
             filteredExpenses = new ArrayList<>();
         }
 
-        Integer totalPrice = expenses.stream()
+        Integer totalPrice = filteredExpenses.stream()
             .mapToInt(Expense::getTotalPrice)
             .reduce(Integer::sum)
             .orElse(0);

--- a/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
@@ -56,7 +56,7 @@ public class ExpenseService {
             filteredExpenses = new ArrayList<>();
         }
 
-        Integer totalPrice = filteredExpenses.stream()
+        Integer totalPrice = expenses.stream()
             .mapToInt(Expense::getTotalPrice)
             .reduce(Integer::sum)
             .orElse(0);

--- a/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
@@ -58,7 +58,8 @@ public class ExpenseService {
 
         Integer totalPrice = expenses.stream()
             .mapToInt(Expense::getTotalPrice)
-            .sum();
+            .reduce(Integer::sum)
+            .orElse(0);
 
         return ExpenseResponse.of(filteredExpenses, isChecked, totalPrice);
     }

--- a/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
@@ -39,7 +39,7 @@ public class ExpenseService {
     private final TeamRepository teamRepository;
 
     @Transactional(readOnly = true)
-    public ExpenseResponse getResponses(Long memberId, Long teamId, Status status,
+    public ExpenseResponse getExpenses(Long memberId, Long teamId, Status status,
         Boolean isChecked) {
         List<Expense> expenses = expenseRepository.findByTeamIdAndStatus(teamId, status);
         List<Expense> filteredExpenses;

--- a/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
@@ -7,11 +7,9 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import kappzzang.jeongsan.domain.Category;
 import kappzzang.jeongsan.domain.Expense;
 import kappzzang.jeongsan.domain.Item;
@@ -134,7 +132,7 @@ public class ExpenseServiceTest {
             items.stream().map(Item::getId).toList())).willReturn(0L);
 
         // when
-        ExpenseResponse response = expenseService.getResponses(memberId, teamId, status, isChecked);
+        ExpenseResponse response = expenseService.getExpenses(memberId, teamId, status, isChecked);
 
         // then
         assertThat(response.expenseList()).isEmpty();
@@ -165,13 +163,13 @@ public class ExpenseServiceTest {
         given(expense.getCategory()).willReturn(mock(Category.class));
 
         // when
-        ExpenseResponse response = expenseService.getResponses(memberId, teamId, status, isChecked);
+        ExpenseResponse response = expenseService.getExpenses(memberId, teamId, status, isChecked);
 
         // then
         assertThat(response.expenseList()).hasSize(1);
         assertThat(response.totalPrice()).isEqualTo(1000);
-        assertThat(response.expenseList().get(0).title()).isEqualTo("Test Expense");
-        assertThat(response.expenseList().get(0).totalPrice()).isEqualTo(1000);
+        assertThat(response.expenseList().getFirst().title()).isEqualTo("Test Expense");
+        assertThat(response.expenseList().getFirst().totalPrice()).isEqualTo(1000);
     }
 
     @Test
@@ -200,12 +198,12 @@ public class ExpenseServiceTest {
             items.stream().map(Item::getId).toList())).willReturn(1L);
 
         // when
-        ExpenseResponse response = expenseService.getResponses(memberId, teamId, status, isChecked);
+        ExpenseResponse response = expenseService.getExpenses(memberId, teamId, status, isChecked);
 
         // then
         assertThat(response.expenseList()).hasSize(1);
         assertThat(response.totalPrice()).isEqualTo(expense.getTotalPrice());
-        assertThat(response.expenseList().get(0).title()).isEqualTo(expense.getTitle());
+        assertThat(response.expenseList().getFirst().title()).isEqualTo(expense.getTitle());
     }
 
 }

--- a/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
@@ -174,7 +174,7 @@ public class ExpenseServiceTest {
         assertThat(response.expenseList().get(0).totalPrice()).isEqualTo(1000);
     }
 
-     @Test
+    @Test
     @DisplayName("지출 목록 반환 - 진행중 상태")
     void getExpenses_Ongoing() {
         // given
@@ -197,7 +197,7 @@ public class ExpenseServiceTest {
         given(mockExpenseRepository.findByTeamIdAndStatus(teamId, status)).willReturn(expenses);
         given(mockItemRepository.findAllByExpenseId(expense.getId())).willReturn(items);
         given(mockPersonalExpenseRepository.countByMemberIdAndItemIds(memberId,
-            items.stream().map(Item::getId).collect(Collectors.toList()))).willReturn(1L);
+            items.stream().map(Item::getId).toList())).willReturn(1L);
 
         // when
         ExpenseResponse response = expenseService.getResponses(memberId, teamId, status, isChecked);

--- a/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
@@ -4,16 +4,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import kappzzang.jeongsan.domain.Category;
 import kappzzang.jeongsan.domain.Expense;
 import kappzzang.jeongsan.domain.Item;
 import kappzzang.jeongsan.dto.ItemDetail;
+import kappzzang.jeongsan.dto.response.ExpenseResponse;
 import kappzzang.jeongsan.dto.response.PersonalExpenseDetailResponse;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
+import kappzzang.jeongsan.global.common.enumeration.Status;
 import kappzzang.jeongsan.global.exception.JeongsanException;
 import kappzzang.jeongsan.repository.ExpenseRepository;
+import kappzzang.jeongsan.repository.ItemRepository;
+import kappzzang.jeongsan.repository.PersonalExpenseRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,6 +46,12 @@ public class ExpenseServiceTest {
 
     @Mock
     private ExpenseRepository mockExpenseRepository;
+
+    @Mock
+    private ItemRepository mockItemRepository;
+
+    @Mock
+    private PersonalExpenseRepository mockPersonalExpenseRepository;
 
     @InjectMocks
     private ExpenseService expenseService;
@@ -96,6 +112,100 @@ public class ExpenseServiceTest {
             .isInstanceOf(JeongsanException.class)
             .hasMessage(ErrorType.EXPENSE_NOT_FOUND.getMessage());
         then(mockExpenseRepository).should().findById(TEST_EXPENSE_ID);
+    }
+
+
+    @Test
+    @DisplayName("지출 목록 조회 - 진행중 상태 빈 경우")
+    void getExpenses_givenNoExpenses_Ongoing_ReturnEmptyResponse() {
+        // given
+        Long memberId = 1L;
+        Long teamId = 1L;
+        Status status = Status.ONGOING;
+        Boolean isChecked = true;
+        Expense expense = mock(Expense.class);
+        Item item = mock(Item.class);
+        List<Expense> expenses = Collections.singletonList(expense);
+        List<Item> items = Collections.singletonList(item);
+
+        given(mockExpenseRepository.findByTeamIdAndStatus(teamId, status)).willReturn(expenses);
+        given(mockItemRepository.findAllByExpenseId(expense.getId())).willReturn(items);
+        given(mockPersonalExpenseRepository.countByMemberIdAndItemIds(memberId,
+            items.stream().map(Item::getId).toList())).willReturn(0L);
+
+        // when
+        ExpenseResponse response = expenseService.getResponses(memberId, teamId, status, isChecked);
+
+        // then
+        assertThat(response.expenseList()).isEmpty();
+        assertThat(response.totalPrice()).isEqualTo(0);
+        assertThat(response.checked()).isTrue();
+
+        then(mockExpenseRepository).should().findByTeamIdAndStatus(teamId, status);
+        then(mockItemRepository).should().findAllByExpenseId(expense.getId());
+    }
+
+    @Test
+    @DisplayName("지출 목록 조회 - 완료 상태")
+    void getExpenses_Completed() {
+        // given
+        Long memberId = 1L;
+        Long teamId = 1L;
+        Status status = Status.COMPLETED;
+        Boolean isChecked = null;
+        Expense expense = mock(Expense.class);
+        List<Expense> expenses = Collections.singletonList(expense);
+
+        given(mockExpenseRepository.findByTeamIdAndStatus(teamId, status)).willReturn(expenses);
+        given(expense.getId()).willReturn(1L);
+        given(expense.getTitle()).willReturn("Test Expense");
+        given(expense.getTotalPrice()).willReturn(1000);
+        given(expense.getCreatedAt()).willReturn(LocalDateTime.now());
+        given(expense.getStatus()).willReturn(Status.COMPLETED);
+        given(expense.getCategory()).willReturn(mock(Category.class));
+
+        // when
+        ExpenseResponse response = expenseService.getResponses(memberId, teamId, status, isChecked);
+
+        // then
+        assertThat(response.expenseList()).hasSize(1);
+        assertThat(response.totalPrice()).isEqualTo(1000);
+        assertThat(response.expenseList().get(0).title()).isEqualTo("Test Expense");
+        assertThat(response.expenseList().get(0).totalPrice()).isEqualTo(1000);
+    }
+
+     @Test
+    @DisplayName("지출 목록 반환 - 진행중 상태")
+    void getExpenses_Ongoing() {
+        // given
+        Long memberId = 1L;
+        Long teamId = 1L;
+        Status status = Status.ONGOING;
+        Boolean isChecked = true;
+        Expense expense = mock(Expense.class);
+        Item item = mock(Item.class);
+        List<Expense> expenses = Collections.singletonList(expense);
+        List<Item> items = Collections.singletonList(item);
+
+        given(expense.getId()).willReturn(1L);
+        given(expense.getTitle()).willReturn("Test Expense");
+        given(expense.getTotalPrice()).willReturn(1000);
+        given(expense.getCreatedAt()).willReturn(LocalDateTime.now());
+        given(expense.getStatus()).willReturn(Status.COMPLETED);
+        given(expense.getCategory()).willReturn(mock(Category.class));
+
+        given(mockExpenseRepository.findByTeamIdAndStatus(teamId, status)).willReturn(expenses);
+        given(mockItemRepository.findAllByExpenseId(expense.getId())).willReturn(items);
+        given(mockPersonalExpenseRepository.countByMemberIdAndItemIds(memberId,
+            items.stream().map(Item::getId).collect(Collectors.toList()))).willReturn(1L);
+
+        // when
+        ExpenseResponse response = expenseService.getResponses(memberId, teamId, status, isChecked);
+
+        // then
+        assertThat(response.expenseList()).hasSize(1);
+        assertThat(response.totalPrice()).isEqualTo(expense.getTotalPrice());
+        assertThat(response.expenseList().get(0).title()).isEqualTo(expense.getTitle());
     }
 
 }


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- ExpenseService의 지출 목록 조회에 대한 테스트 코드를 추가했습니다
- 지출 목록 조회에서 나오는 totalPrice의 합을 구할 때, 지출 목록이 존재하지 않으면 0을 반환하도록 수정했습니다

### 🔍 참고 사항
- ExpenseRepository에 주석처리로 있는 JPQL을 적용하기 위해서는 실제 DB 데이터를 통한 테스트를 해야되므로 통합테스트를 별도로 구현해야합니다

### ⚠️ 의논 필요
- X

### 🐞현재 버그
- X

### #️⃣ 연관 이슈(Git Close)
- close #63 
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
