### PR TITLE
Feature/issue#80: Access 토큰 재발급 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
 	// JWT
-	compileOnly 'io.jsonwebtoken:jjwt-api:0.12.6'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 

--- a/src/main/java/kappzzang/jeongsan/controller/MemberController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/MemberController.java
@@ -39,7 +39,7 @@ public class MemberController implements MemberControllerInterface {
     @Override
     @PostMapping("/token/refresh")
     public ResponseEntity<JeongsanApiResponse<RefreshResponse>> refresh(
-        @AuthenticationPrincipal Long memberId, @Valid RefreshRequest refreshRequest) {
+        @AuthenticationPrincipal Long memberId, @Valid @RequestBody RefreshRequest refreshRequest) {
         return JeongsanApiResponse.success(SuccessType.ACCESS_TOKEN_REISSUED,
             memberService.refresh(memberId, refreshRequest));
     }

--- a/src/main/java/kappzzang/jeongsan/controller/MemberController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/MemberController.java
@@ -5,12 +5,15 @@ import static kappzzang.jeongsan.global.common.enumeration.SuccessType.JOIN_SUCC
 import kappzzang.jeongsan.controller.docs.MemberControllerInterface;
 import kappzzang.jeongsan.dto.request.JoinTeamRequest;
 import kappzzang.jeongsan.dto.request.LoginRequest;
+import kappzzang.jeongsan.dto.request.RefreshRequest;
 import kappzzang.jeongsan.dto.response.LoginResponse;
+import kappzzang.jeongsan.dto.response.RefreshResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
 import kappzzang.jeongsan.global.common.enumeration.SuccessType;
 import kappzzang.jeongsan.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,6 +33,14 @@ public class MemberController implements MemberControllerInterface {
         @RequestBody LoginRequest loginRequest) {
         return JeongsanApiResponse.success(SuccessType.LOGGED_IN,
             memberService.login(loginRequest));
+    }
+
+    @Override
+    @PostMapping("/token/refresh")
+    public ResponseEntity<JeongsanApiResponse<RefreshResponse>> refresh(
+        @AuthenticationPrincipal Long memberId, RefreshRequest refreshRequest) {
+        return JeongsanApiResponse.success(SuccessType.ACCESS_TOKEN_REISSUED,
+            memberService.refresh(memberId, refreshRequest));
     }
 
     @Override

--- a/src/main/java/kappzzang/jeongsan/controller/MemberController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/MemberController.java
@@ -2,6 +2,7 @@ package kappzzang.jeongsan.controller;
 
 import static kappzzang.jeongsan.global.common.enumeration.SuccessType.JOIN_SUCCESS;
 
+import jakarta.validation.Valid;
 import kappzzang.jeongsan.controller.docs.MemberControllerInterface;
 import kappzzang.jeongsan.dto.request.JoinTeamRequest;
 import kappzzang.jeongsan.dto.request.LoginRequest;
@@ -30,7 +31,7 @@ public class MemberController implements MemberControllerInterface {
     @Override
     @PostMapping("/token")
     public ResponseEntity<JeongsanApiResponse<LoginResponse>> login(
-        @RequestBody LoginRequest loginRequest) {
+        @Valid @RequestBody LoginRequest loginRequest) {
         return JeongsanApiResponse.success(SuccessType.LOGGED_IN,
             memberService.login(loginRequest));
     }
@@ -38,7 +39,7 @@ public class MemberController implements MemberControllerInterface {
     @Override
     @PostMapping("/token/refresh")
     public ResponseEntity<JeongsanApiResponse<RefreshResponse>> refresh(
-        @AuthenticationPrincipal Long memberId, RefreshRequest refreshRequest) {
+        @AuthenticationPrincipal Long memberId, @Valid RefreshRequest refreshRequest) {
         return JeongsanApiResponse.success(SuccessType.ACCESS_TOKEN_REISSUED,
             memberService.refresh(memberId, refreshRequest));
     }

--- a/src/main/java/kappzzang/jeongsan/controller/docs/MemberControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/MemberControllerInterface.java
@@ -6,7 +6,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kappzzang.jeongsan.dto.request.JoinTeamRequest;
 import kappzzang.jeongsan.dto.request.LoginRequest;
+import kappzzang.jeongsan.dto.request.RefreshRequest;
 import kappzzang.jeongsan.dto.response.LoginResponse;
+import kappzzang.jeongsan.dto.response.RefreshResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
 import org.springframework.http.ResponseEntity;
 
@@ -19,11 +21,21 @@ public interface MemberControllerInterface {
         @ApiResponse(responseCode = "500", description = "외부 API 호출 중 오류 발생. (ErrorCode-E500003)")})
     ResponseEntity<JeongsanApiResponse<LoginResponse>> login(LoginRequest loginRequest);
 
+    @Operation(summary = "액세스 토큰 재발급 API", description = "리프레시 토큰으로 액세스 토큰을 받는 API")
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "액세스 토큰 재발급 성공"),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음. (ErrorCode-E404001)"),
+        @ApiResponse(responseCode = "403", description = "리프레시 토큰이 유효하지 않음. (ErrorCode-E403001)"),
+        @ApiResponse(responseCode = "401", description = "토큰 서명이 유효하지 않음. (ErrorCode-E401001"),
+        @ApiResponse(responseCode = "401", description = "토큰이 만료됨. (ErrorCode-E401002)"),
+        @ApiResponse(responseCode = "401", description = "토큰 형식이 잘못됨. (ErrorCode-E401003)")})
+    ResponseEntity<JeongsanApiResponse<RefreshResponse>> refresh(Long memberId,
+        RefreshRequest refreshRequest);
+
     @Operation(summary = "모임 초대 수락 API", description = "모임 초대 링크를 받은 사용자가 모임 참여를 수락하여 모임에 참여하도록 하는 API")
     @ApiResponses({@ApiResponse(responseCode = "204", description = "모임 초대 수락, 모임 참여 성공"),
         @ApiResponse(responseCode = "400", description = "모임에 초대 되지 않은 멤버. (ErrorCode-E400002"),
         @ApiResponse(responseCode = "400", description = "이미 모임에 참여중인 멤버. (ErrorCode-E400003)"),
-        @ApiResponse(responseCode = "404", description = "잘못된 teamId, 모임을 찾을 수 없음. (ErrorCode-E404002)"),
-        @ApiResponse(responseCode = "404", description = "잘못된 memberId, 사용자를 찾을 수 없음. (ErrorCode-E404003)")})
+        @ApiResponse(responseCode = "404", description = "잘못된 memberId, 사용자를 찾을 수 없음. (ErrorCode-E404001)"),
+        @ApiResponse(responseCode = "404", description = "잘못된 teamId, 모임을 찾을 수 없음. (ErrorCode-E404002)"),})
     ResponseEntity<JeongsanApiResponse<Void>> joinTeam(Long teamId, JoinTeamRequest request);
 }

--- a/src/main/java/kappzzang/jeongsan/controller/docs/MemberControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/MemberControllerInterface.java
@@ -33,10 +33,7 @@ public interface MemberControllerInterface {
     })
     @ApiResponses({@ApiResponse(responseCode = "200", description = "액세스 토큰 재발급 성공"),
         @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음. (ErrorCode-E404001)"),
-        @ApiResponse(responseCode = "403", description = "리프레시 토큰이 유효하지 않음. (ErrorCode-E403001)"),
-        @ApiResponse(responseCode = "401", description = "토큰 서명이 유효하지 않음. (ErrorCode-E401001"),
-        @ApiResponse(responseCode = "401", description = "토큰이 만료됨. (ErrorCode-E401002)"),
-        @ApiResponse(responseCode = "401", description = "토큰 형식이 잘못됨. (ErrorCode-E401003)")})
+        @ApiResponse(responseCode = "403", description = "리프레시 토큰이 유효하지 않음. (ErrorCode-E403001)")})
     ResponseEntity<JeongsanApiResponse<RefreshResponse>> refresh(Long memberId,
         RefreshRequest refreshRequest);
 
@@ -45,6 +42,6 @@ public interface MemberControllerInterface {
         @ApiResponse(responseCode = "400", description = "모임에 초대 되지 않은 멤버. (ErrorCode-E400002"),
         @ApiResponse(responseCode = "400", description = "이미 모임에 참여중인 멤버. (ErrorCode-E400003)"),
         @ApiResponse(responseCode = "404", description = "잘못된 memberId, 사용자를 찾을 수 없음. (ErrorCode-E404001)"),
-        @ApiResponse(responseCode = "404", description = "잘못된 teamId, 모임을 찾을 수 없음. (ErrorCode-E404002)"),})
+        @ApiResponse(responseCode = "404", description = "잘못된 teamId, 모임을 찾을 수 없음. (ErrorCode-E404002)")})
     ResponseEntity<JeongsanApiResponse<Void>> joinTeam(Long teamId, JoinTeamRequest request);
 }

--- a/src/main/java/kappzzang/jeongsan/controller/docs/MemberControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/MemberControllerInterface.java
@@ -1,6 +1,8 @@
 package kappzzang.jeongsan.controller.docs;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -16,12 +18,19 @@ import org.springframework.http.ResponseEntity;
 public interface MemberControllerInterface {
 
     @Operation(summary = "로그인 API", description = "카카오 토큰으로 회원가입 및 로그인하여 액세스 토큰을 받는 API")
+    @Parameters({
+        @Parameter(name = "tokenType", description = "카카오 액세스 토큰 타입"),
+        @Parameter(name = "accessToken", description = "카카오 액세스 토큰")
+    })
     @ApiResponses({@ApiResponse(responseCode = "201", description = "로그인 성공"),
         @ApiResponse(responseCode = "408", description = "외부 API 요청 시간 초과. (ErrorCode-E408001"),
         @ApiResponse(responseCode = "500", description = "외부 API 호출 중 오류 발생. (ErrorCode-E500003)")})
     ResponseEntity<JeongsanApiResponse<LoginResponse>> login(LoginRequest loginRequest);
 
     @Operation(summary = "액세스 토큰 재발급 API", description = "리프레시 토큰으로 액세스 토큰을 받는 API")
+    @Parameters({
+        @Parameter(name = "refreshToken", description = "서비스 서버 리프레시 토큰")
+    })
     @ApiResponses({@ApiResponse(responseCode = "200", description = "액세스 토큰 재발급 성공"),
         @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음. (ErrorCode-E404001)"),
         @ApiResponse(responseCode = "403", description = "리프레시 토큰이 유효하지 않음. (ErrorCode-E403001)"),

--- a/src/main/java/kappzzang/jeongsan/dto/request/LoginRequest.java
+++ b/src/main/java/kappzzang/jeongsan/dto/request/LoginRequest.java
@@ -1,6 +1,9 @@
 package kappzzang.jeongsan.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record LoginRequest(
+    @NotBlank
     String accessToken
 ) {
 

--- a/src/main/java/kappzzang/jeongsan/dto/request/RefreshRequest.java
+++ b/src/main/java/kappzzang/jeongsan/dto/request/RefreshRequest.java
@@ -1,0 +1,10 @@
+package kappzzang.jeongsan.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequest(
+    @NotBlank
+    String refreshToken
+) {
+
+}

--- a/src/main/java/kappzzang/jeongsan/dto/response/RefreshResponse.java
+++ b/src/main/java/kappzzang/jeongsan/dto/response/RefreshResponse.java
@@ -1,0 +1,8 @@
+package kappzzang.jeongsan.dto.response;
+
+public record RefreshResponse(
+    String tokenType,
+    String accessToken
+) {
+
+}

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
@@ -20,6 +20,9 @@ public enum ErrorType {
     JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "E401002", "토큰이 만료되었습니다."),
     JWT_MALFORMED(HttpStatus.UNAUTHORIZED, "E401003", "토큰 형식이 잘못되었습니다."),
 
+    // 403 FORBIDDEN
+    REFRESH_TOKEN_INVALID(HttpStatus.FORBIDDEN, "E403001", "리프레시 토큰이 유효하지 않습니다."),
+
     // 404 NOT_FOUND
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "E404001", "사용자를 찾을 수 없습니다."),
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "E404002", "모임을 찾을 수 없습니다."),

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
@@ -13,6 +13,7 @@ public enum SuccessType {
     EXPENSE_LIST_LOADED(HttpStatus.OK, "지출 목록을 불러오는 데 성공했습니다"),
     PERSONAL_EXPENSE_LOADED(HttpStatus.OK, "개인 지출 목록을 불러오는 데 성공했습니다."),
     INVITATION_STATUS_LOADED(HttpStatus.OK, "모임의 멤버 초대 현황을 불러오는 데 성공했습니다."),
+    ACCESS_TOKEN_REISSUED(HttpStatus.OK, "액세스 토큰이 재발급되었습니다."),
 
     // 201 CREATED
     TEAM_CREATED(HttpStatus.CREATED, "모임이 생성되었습니다."),

--- a/src/main/java/kappzzang/jeongsan/global/security/JwtAuthenticationProvider.java
+++ b/src/main/java/kappzzang/jeongsan/global/security/JwtAuthenticationProvider.java
@@ -1,10 +1,5 @@
 package kappzzang.jeongsan.global.security;
 
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.security.SignatureException;
-import kappzzang.jeongsan.global.common.enumeration.ErrorType;
-import kappzzang.jeongsan.global.exception.JeongsanException;
 import kappzzang.jeongsan.global.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -20,19 +15,11 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
     // JWT를 파싱하여 Authentication 생성
     @Override
     public Authentication authenticate(Authentication authentication) {
-        try {
-            String token = ((JwtAuthenticationToken) authentication).getToken();
-            Long memberId = jwtUtil.getMemberId(token);
+        String token = ((JwtAuthenticationToken) authentication).getToken();
+        Long memberId = jwtUtil.getMemberId(token);
 
-            // 사용자 role은 아직 없음
-            return new JwtAuthenticationToken(memberId, null, null);
-        } catch (SignatureException signatureException) {
-            throw new JeongsanException(ErrorType.JWT_SIGNATURE_INVALID);
-        } catch (ExpiredJwtException expiredJwtException) {
-            throw new JeongsanException(ErrorType.JWT_EXPIRED);
-        } catch (MalformedJwtException malformedJwtException) {
-            throw new JeongsanException(ErrorType.JWT_MALFORMED);
-        }
+        // 사용자 role은 아직 없음
+        return new JwtAuthenticationToken(memberId, null, null);
     }
 
     // filter로부터 받은 AuthenticationToken이 해당 provider가 지원하는 타입인지 확인

--- a/src/main/java/kappzzang/jeongsan/global/util/JwtUtil.java
+++ b/src/main/java/kappzzang/jeongsan/global/util/JwtUtil.java
@@ -87,12 +87,12 @@ public class JwtUtil {
     }
 
     private long createIssueAt(LocalDateTime now) {
-        return now.atZone(ZoneId.systemDefault()).toEpochSecond();
+        return now.atZone(ZoneId.of("Asia/Seoul")).toEpochSecond();
     }
 
     private long createExpiration(LocalDateTime now, long expirationTime) {
         return now.plus(expirationTime, ChronoUnit.MILLIS)
-            .atZone(ZoneId.systemDefault())
+            .atZone(ZoneId.of("Asia/Seoul"))
             .toEpochSecond();
     }
 }

--- a/src/main/java/kappzzang/jeongsan/global/util/JwtUtil.java
+++ b/src/main/java/kappzzang/jeongsan/global/util/JwtUtil.java
@@ -1,6 +1,5 @@
 package kappzzang.jeongsan.global.util;
 
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
@@ -39,13 +38,14 @@ public class JwtUtil {
         return null;
     }
 
-    public Claims parseClaims(String token) {
+    public Long getMemberId(String token) {
         try {
-            return Jwts.parser()
+            return Long.parseLong(Jwts.parser()
                 .verifyWith(secretKey)
                 .build()
                 .parseSignedClaims(token)
-                .getPayload();
+                .getPayload()
+                .getSubject());
         } catch (SignatureException signatureException) {
             throw new JeongsanException(ErrorType.JWT_SIGNATURE_INVALID);
         } catch (ExpiredJwtException expiredJwtException) {
@@ -55,8 +55,16 @@ public class JwtUtil {
         }
     }
 
-    public Long getMemberId(String token) {
-        return Long.parseLong(parseClaims(token).getSubject());
+    public boolean validateRefreshToken(String refreshToken) {
+        try {
+            Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(refreshToken);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     public String createAccessToken(Long id) {

--- a/src/main/java/kappzzang/jeongsan/service/MemberService.java
+++ b/src/main/java/kappzzang/jeongsan/service/MemberService.java
@@ -57,10 +57,10 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new JeongsanException(USER_NOT_FOUND));
         String refreshToken = refreshRequest.refreshToken();
-        if(!refreshToken.equals(member.getRefreshToken())) {
+        if (!refreshToken.equals(member.getRefreshToken())
+            || !jwtUtil.validateRefreshToken(refreshToken)) {
             throw new JeongsanException(REFRESH_TOKEN_INVALID);
         }
-        jwtUtil.parseClaims(refreshToken);
 
         return new RefreshResponse(BEARER, jwtUtil.createAccessToken(memberId));
     }

--- a/src/main/java/kappzzang/jeongsan/service/MemberService.java
+++ b/src/main/java/kappzzang/jeongsan/service/MemberService.java
@@ -1,6 +1,7 @@
 package kappzzang.jeongsan.service;
 
 import static kappzzang.jeongsan.global.common.enumeration.ErrorType.NOT_INVITED_MEMBER;
+import static kappzzang.jeongsan.global.common.enumeration.ErrorType.REFRESH_TOKEN_INVALID;
 import static kappzzang.jeongsan.global.common.enumeration.ErrorType.TEAM_NOT_FOUND;
 import static kappzzang.jeongsan.global.common.enumeration.ErrorType.USER_NOT_FOUND;
 
@@ -8,7 +9,9 @@ import kappzzang.jeongsan.domain.Member;
 import kappzzang.jeongsan.domain.Team;
 import kappzzang.jeongsan.domain.TeamMember;
 import kappzzang.jeongsan.dto.request.LoginRequest;
+import kappzzang.jeongsan.dto.request.RefreshRequest;
 import kappzzang.jeongsan.dto.response.LoginResponse;
+import kappzzang.jeongsan.dto.response.RefreshResponse;
 import kappzzang.jeongsan.global.client.dto.response.KakaoProfileResponse;
 import kappzzang.jeongsan.global.client.kakao.KakaoApiClient;
 import kappzzang.jeongsan.global.exception.JeongsanException;
@@ -47,6 +50,19 @@ public class MemberService {
         memberRepository.save(member);
 
         return new LoginResponse(BEARER, accessToken, refreshToken);
+    }
+
+    @Transactional
+    public RefreshResponse refresh(Long memberId, RefreshRequest refreshRequest) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new JeongsanException(USER_NOT_FOUND));
+        String refreshToken = refreshRequest.refreshToken();
+        if(!refreshToken.equals(member.getRefreshToken())) {
+            throw new JeongsanException(REFRESH_TOKEN_INVALID);
+        }
+        jwtUtil.parseClaims(refreshToken);
+
+        return new RefreshResponse(BEARER, jwtUtil.createAccessToken(memberId));
     }
 
     @Transactional

--- a/src/test/java/kappzzang/jeongsan/service/MemberServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/MemberServiceTest.java
@@ -1,20 +1,28 @@
 package kappzzang.jeongsan.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
+import io.jsonwebtoken.Claims;
 import java.util.Optional;
 import kappzzang.jeongsan.domain.Member;
 import kappzzang.jeongsan.dto.request.LoginRequest;
+import kappzzang.jeongsan.dto.request.RefreshRequest;
 import kappzzang.jeongsan.dto.response.LoginResponse;
+import kappzzang.jeongsan.dto.response.RefreshResponse;
 import kappzzang.jeongsan.global.client.dto.response.KakaoProfileResponse;
 import kappzzang.jeongsan.global.client.dto.response.KakaoProfileResponse.ForPartner;
 import kappzzang.jeongsan.global.client.dto.response.KakaoProfileResponse.KakaoAccount;
 import kappzzang.jeongsan.global.client.dto.response.KakaoProfileResponse.KakaoAccount.Profile;
 import kappzzang.jeongsan.global.client.kakao.KakaoApiClient;
+import kappzzang.jeongsan.global.exception.JeongsanException;
 import kappzzang.jeongsan.global.util.JwtUtil;
 import kappzzang.jeongsan.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -46,7 +54,7 @@ public class MemberServiceTest {
     @Test
     @DisplayName("카카오 로그인으로 회원가입 및 토큰 발급 성공")
     void login() {
-        // Given
+        // given
         KakaoProfileResponse kakaoProfileResponse = createKakaoProfileResponse();
         given(kakaoApiClient.getKakaoProfile(anyString())).willReturn(kakaoProfileResponse);
         given(memberRepository.findByKakaoId(anyString())).willReturn(Optional.empty());
@@ -54,14 +62,56 @@ public class MemberServiceTest {
         given(jwtUtil.createAccessToken(any())).willReturn(TEST_ACCESS_TOKEN);
         given(jwtUtil.createRefreshToken()).willReturn(TEST_REFRESH_TOKEN);
 
-        // When
+        // when
         LoginResponse loginResponse = memberService.login(new LoginRequest(anyString()));
 
-        // Then
+        // then
         then(memberRepository).should(times(2)).save(any(Member.class));
-        then(loginResponse.tokenType()).equals(BEARER);
-        then(loginResponse.accessToken()).equals(TEST_ACCESS_TOKEN);
-        then(loginResponse.refreshToken()).equals(TEST_REFRESH_TOKEN);
+        assertThat(loginResponse.tokenType()).isEqualTo(BEARER);
+        assertThat(loginResponse.accessToken()).isEqualTo(TEST_ACCESS_TOKEN);
+        assertThat(loginResponse.refreshToken()).isEqualTo(TEST_REFRESH_TOKEN);
+    }
+
+    @Test
+    @DisplayName("액세스 토큰 재발급 실패 - 일치하지 않은 리프레시 토큰")
+    void refreshWithMismatchedRefreshToken() {
+        // given
+        RefreshRequest refreshRequest = new RefreshRequest("RefreshToken");
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(createMember()));
+
+        // when & then
+        assertThatThrownBy(() -> memberService.refresh(anyLong(), refreshRequest))
+            .isInstanceOf(JeongsanException.class);
+    }
+
+    @Test
+    @DisplayName("액세스 토큰 재발급 실패 - 유효하지 않은 리프레시 토큰")
+    void refreshWithInvalidRefreshToken() {
+        // given
+        RefreshRequest refreshRequest = new RefreshRequest(TEST_REFRESH_TOKEN);
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(createMember()));
+        given(jwtUtil.parseClaims(TEST_REFRESH_TOKEN)).willThrow(JeongsanException.class);
+
+        // when & then
+        assertThatThrownBy(() -> memberService.refresh(anyLong(), refreshRequest))
+            .isInstanceOf(JeongsanException.class);
+    }
+
+    @Test
+    @DisplayName("액세스 토큰 재발급 성공")
+    void refresh() {
+        // given
+        RefreshRequest refreshRequest = new RefreshRequest(TEST_REFRESH_TOKEN);
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(createMember()));
+        given(jwtUtil.parseClaims(TEST_REFRESH_TOKEN)).willReturn(mock(Claims.class));
+        given(jwtUtil.createAccessToken(anyLong())).willReturn(TEST_ACCESS_TOKEN);
+
+        // when
+        RefreshResponse refreshResponse = memberService.refresh(anyLong(), refreshRequest);
+
+        // then
+        assertThat(refreshResponse.tokenType()).isEqualTo(BEARER);
+        assertThat(refreshResponse.accessToken()).isEqualTo(TEST_ACCESS_TOKEN);
     }
 
     private KakaoProfileResponse createKakaoProfileResponse() {
@@ -69,5 +119,11 @@ public class MemberServiceTest {
         KakaoAccount kakaoAccount = new KakaoAccount("sample@sample.com", profile);
         ForPartner forPartner = new ForPartner("550e8400-e29b-41d4-a716-446655440000");
         return new KakaoProfileResponse(kakaoAccount, forPartner);
+    }
+
+    private Member createMember() {
+        return Member.builder()
+            .refreshToken(TEST_REFRESH_TOKEN)
+            .build();
     }
 }


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 토큰 생성 시 Date 대신 LocalDateTime 사용하도록 수정
- Refresh 토큰으로 Access 토큰 재발급하는 로직 추가

### 🔍 참고 사항
- 테스트 코드에서 JwtUtil 관련 코드가 인식되지 않아 jwt 의존성 옵션을 수정하였습니다. `compileOnly` -> `implementation`
- 구글 독스 API 명세에 토큰 재발급 API를 업데이트하였습니다.

### ⚠️ 의논 필요
X

### 🐞현재 버그
X

### #️⃣ 연관 이슈(Git Close)
- close #80 
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
