### PR TITLE
Feature/issue#86: 개인 소비 내역 저장 api 구현

### DIFF
--- a/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
@@ -52,9 +52,11 @@ public class ExpenseController implements ExpenseControllerInterface {
             expenseService.getExpenses(memberId, teamId, status, isChecked));
     }
 
-    @PostMapping("/personal/{teamId}/{expenseId}/{memberId}")
+    @PostMapping("/personal/{teamId}/{expenseId}")
     public ResponseEntity<JeongsanApiResponse<Void>> savePersonalExpense(
-        @PathVariable("teamId") Long teamId, @PathVariable("expenseId") Long expenseId, @PathVariable("memberId") Long memberId,
+        @AuthenticationPrincipal Long memberId,
+        @PathVariable("teamId") Long teamId,
+        @PathVariable("expenseId") Long expenseId,
         @Valid @RequestBody SavePersonalExpenseRequest personalExpense) {
         personalExpenseService.savePersonalExpense(memberId, teamId, expenseId, personalExpense);
         return JeongsanApiResponse.success(SuccessType.PERSONAL_EXPENSE_SAVED);

--- a/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
@@ -1,6 +1,8 @@
 package kappzzang.jeongsan.controller;
 
+import jakarta.validation.Valid;
 import kappzzang.jeongsan.controller.docs.ExpenseControllerInterface;
+import kappzzang.jeongsan.dto.request.SavePersonalExpenseRequest;
 import kappzzang.jeongsan.dto.response.ExpenseResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
@@ -8,10 +10,13 @@ import kappzzang.jeongsan.global.common.enumeration.Status;
 import kappzzang.jeongsan.global.common.enumeration.SuccessType;
 import kappzzang.jeongsan.global.exception.JeongsanException;
 import kappzzang.jeongsan.service.ExpenseService;
+import kappzzang.jeongsan.service.PersonalExpenseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,12 +27,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class ExpenseController implements ExpenseControllerInterface {
 
     private final ExpenseService expenseService;
+    private final PersonalExpenseService personalExpenseService;
 
     @Override
     @GetMapping("{teamId}")
     public ResponseEntity<JeongsanApiResponse<ExpenseResponse>> getAllExpenses(
-        @PathVariable Long teamId,
-        @RequestParam String state,
+        @PathVariable Long teamId, @RequestParam String state,
         @RequestParam(required = false) Boolean isChecked) {
         Status status;
         try {
@@ -42,5 +47,13 @@ public class ExpenseController implements ExpenseControllerInterface {
 
         return JeongsanApiResponse.success(SuccessType.EXPENSE_LIST_LOADED,
             expenseService.getResponses(1L, teamId, status, isChecked));
+    }
+
+    @PostMapping("/personal/{teamId}/{expenseId}")
+    public ResponseEntity<JeongsanApiResponse<Void>> savePersonalExpense(
+        @PathVariable("teamId") Long teamId, @PathVariable("expenseId") Long expenseId,
+        @Valid @RequestBody SavePersonalExpenseRequest personalExpense) {
+        personalExpenseService.savePersonalExpense(1L, teamId, expenseId, personalExpense);
+        return JeongsanApiResponse.success(SuccessType.PERSONAL_EXPENSE_SAVED);
     }
 }

--- a/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
@@ -49,11 +49,11 @@ public class ExpenseController implements ExpenseControllerInterface {
             expenseService.getResponses(1L, teamId, status, isChecked));
     }
 
-    @PostMapping("/personal/{teamId}/{expenseId}")
+    @PostMapping("/personal/{teamId}/{expenseId}/{memberId}")
     public ResponseEntity<JeongsanApiResponse<Void>> savePersonalExpense(
-        @PathVariable("teamId") Long teamId, @PathVariable("expenseId") Long expenseId,
+        @PathVariable("teamId") Long teamId, @PathVariable("expenseId") Long expenseId, @PathVariable("memberId") Long memberId,
         @Valid @RequestBody SavePersonalExpenseRequest personalExpense) {
-        personalExpenseService.savePersonalExpense(1L, teamId, expenseId, personalExpense);
+        personalExpenseService.savePersonalExpense(memberId, teamId, expenseId, personalExpense);
         return JeongsanApiResponse.success(SuccessType.PERSONAL_EXPENSE_SAVED);
     }
 }

--- a/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
@@ -52,6 +52,7 @@ public class ExpenseController implements ExpenseControllerInterface {
             expenseService.getExpenses(memberId, teamId, status, isChecked));
     }
 
+    @Override
     @PostMapping("/personal/{teamId}/{expenseId}")
     public ResponseEntity<JeongsanApiResponse<Void>> savePersonalExpense(
         @AuthenticationPrincipal Long memberId,

--- a/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kappzzang.jeongsan.dto.request.SavePersonalExpenseRequest;
 import kappzzang.jeongsan.dto.response.ExpenseResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -30,4 +31,18 @@ public interface ExpenseControllerInterface {
     })
     ResponseEntity<JeongsanApiResponse<ExpenseResponse>> getAllExpenses(Long memberId, Long teamId,
         String state, Boolean isChecked);
+
+    @Operation(summary = "지출 내역 저장(선택 완료) API", description = "개인이 소비한 품목(아이템)을 선택하여 저장하는 API")
+    @Parameters({
+        @Parameter(name = "teamId", description = "요청 멤버가 속한 모임의 ID"),
+        @Parameter(name = "expenseId", description = "선택한 아이템이 속한 지출의 ID"),
+    })
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "개인 소비 내역 저장 성공", content = @Content),
+        @ApiResponse(responseCode = "400", description = "아이템 quantity 보다 많은 선택 수량 (ErrorCode=E400)", content = @Content),
+        @ApiResponse(responseCode = "400", description = "이전에 선택하여 저장 한 아이템이 포함된 요청 (ErrorCode-E400)", content = @Content),
+        @ApiResponse(responseCode = "404", description = "`teamId`, `expenseId`, `itemId`에 해당하는 데이터가 존재하지 않음 (ErrorCode-E404002, 004, 00?)", content = @Content)
+    })
+    ResponseEntity<JeongsanApiResponse<Void>> savePersonalExpense(Long memberId, Long teamId,
+        Long expenseId, SavePersonalExpenseRequest personalExpense);
 }

--- a/src/main/java/kappzzang/jeongsan/domain/PersonalExpense.java
+++ b/src/main/java/kappzzang/jeongsan/domain/PersonalExpense.java
@@ -9,12 +9,15 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
 import kappzzang.jeongsan.global.exception.JeongsanException;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
 @NoArgsConstructor
 public class PersonalExpense extends BaseEntity {
 

--- a/src/main/java/kappzzang/jeongsan/domain/PersonalExpense.java
+++ b/src/main/java/kappzzang/jeongsan/domain/PersonalExpense.java
@@ -36,6 +36,8 @@ public class PersonalExpense extends BaseEntity {
     private Integer quantity;
     private Integer totalPrice;
 
+
+    // 아래 메서드들 정리 필요
     @Builder
     public PersonalExpense(Member member, Integer quantity) {
         this.member = member;

--- a/src/main/java/kappzzang/jeongsan/dto/request/SavePersonalExpenseRequest.java
+++ b/src/main/java/kappzzang/jeongsan/dto/request/SavePersonalExpenseRequest.java
@@ -1,0 +1,13 @@
+package kappzzang.jeongsan.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+
+public record SavePersonalExpenseRequest(@NotEmpty List<ItemInfo> items) {
+
+    public record ItemInfo(@NotEmpty Long itemId, @Positive Integer quantity) {
+
+    }
+
+}

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
@@ -15,6 +15,7 @@ public enum ErrorType {
     ALREADY_JOINED_MEMBER(HttpStatus.BAD_REQUEST, "E400005", "이미 모임에 참여한 멤버입니다."),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "E400006", "요청 입력값이 유효하지 않습니다."),
     INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "E400", "잘못된 quantity 값 요청입니다."),
+    ALREADY_CHECKED_ITEM(HttpStatus.BAD_REQUEST, "E400", "이미 선택 완료 한 품목이 포함된 요청입니다."),
 
     // 401 UNAUTHORIZED
     JWT_SIGNATURE_INVALID(HttpStatus.UNAUTHORIZED, "E401001", "토큰 서명이 유효하지 않습니다."),

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
@@ -14,6 +14,7 @@ public enum ErrorType {
     NOT_INVITED_MEMBER(HttpStatus.BAD_REQUEST, "E400004", "해당 모임에 초대되지 않은 멤버입니다."),
     ALREADY_JOINED_MEMBER(HttpStatus.BAD_REQUEST, "E400005", "이미 모임에 참여한 멤버입니다."),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "E400006", "요청 입력값이 유효하지 않습니다."),
+    INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "E400", "잘못된 quantity 값 요청입니다."),
 
     // 401 UNAUTHORIZED
     JWT_SIGNATURE_INVALID(HttpStatus.UNAUTHORIZED, "E401001", "토큰 서명이 유효하지 않습니다."),
@@ -27,6 +28,7 @@ public enum ErrorType {
     EXPENSE_NOT_FOUND(HttpStatus.NOT_FOUND, "E404004", "지출을 찾을 수 없습니다."),
     PERSONAL_EXPENSE_NOT_FOUND(HttpStatus.NOT_FOUND, "E404005", "개인 지출을 찾을 수 없습니다."),
     INVITATION_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "E404006", "초대 현황을 찾을 수 없습니다."),
+    ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "E404", "아이템(영수증 품목)을 찾을 수 없습니다."),
 
     //408 REQUEST_TIMEOUT
     EXTERNAL_API_REQUEST_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "E408001", "외부 API 요청 시간이 초과되었습니다."),

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
@@ -13,6 +13,7 @@ public enum SuccessType {
     EXPENSE_LIST_LOADED(HttpStatus.OK, "지출 목록을 불러오는 데 성공했습니다"),
     PERSONAL_EXPENSE_LOADED(HttpStatus.OK, "개인 지출 목록을 불러오는 데 성공했습니다."),
     INVITATION_STATUS_LOADED(HttpStatus.OK, "모임의 멤버 초대 현황을 불러오는 데 성공했습니다."),
+    PERSONAL_EXPENSE_SAVED(HttpStatus.OK, "개인 소비 내역이 저장되었습니다."),
 
     // 201 CREATED
     TEAM_CREATED(HttpStatus.CREATED, "모임이 생성되었습니다."),

--- a/src/main/java/kappzzang/jeongsan/global/config/SecurityConfig.java
+++ b/src/main/java/kappzzang/jeongsan/global/config/SecurityConfig.java
@@ -32,9 +32,9 @@ public class SecurityConfig {
                 (config) -> config.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests((registry) -> registry
                 // 개발할 땐 모든 경로 접근 허용
-                .anyRequest().permitAll()
+                .anyRequest()
+                .permitAll()
             )
-            .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
             .addFilterAfter(
                 new JwtAuthenticationFilter(jwtUtil, authenticationManagerBuilder.getOrBuild()),
                 LogoutFilter.class)

--- a/src/main/java/kappzzang/jeongsan/global/config/SecurityConfig.java
+++ b/src/main/java/kappzzang/jeongsan/global/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
@@ -31,9 +32,9 @@ public class SecurityConfig {
                 (config) -> config.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests((registry) -> registry
                 // 개발할 땐 모든 경로 접근 허용
-                .anyRequest()
-                .permitAll()
+                .anyRequest().permitAll()
             )
+            .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
             .addFilterAfter(
                 new JwtAuthenticationFilter(jwtUtil, authenticationManagerBuilder.getOrBuild()),
                 LogoutFilter.class)

--- a/src/main/java/kappzzang/jeongsan/repository/PersonalExpenseRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/PersonalExpenseRepository.java
@@ -1,7 +1,9 @@
 package kappzzang.jeongsan.repository;
 
 import java.util.List;
+import java.util.Optional;
 import kappzzang.jeongsan.domain.Item;
+import kappzzang.jeongsan.domain.Member;
 import kappzzang.jeongsan.domain.PersonalExpense;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,9 +18,7 @@ public interface PersonalExpenseRepository extends JpaRepository<PersonalExpense
     Long countByMemberIdAndItemIds(@Param("memberId") Long memberId,
         @Param("itemIds") List<Long> itemIds);
 
-//    @Query("SELECT SUM(pe.quantity) FROM PersonalExpense pe "
-//        + "WHERE pe.item.id = :itemId")
-//    Long countQuantityByItemId(@Param("itemId") Long itemId);
-
     List<PersonalExpense> findAllByItem(Item item);
+
+    Optional<PersonalExpense> findByMemberAndItem(Member member, Item item);
 }

--- a/src/main/java/kappzzang/jeongsan/repository/PersonalExpenseRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/PersonalExpenseRepository.java
@@ -1,6 +1,7 @@
 package kappzzang.jeongsan.repository;
 
 import java.util.List;
+import kappzzang.jeongsan.domain.Item;
 import kappzzang.jeongsan.domain.PersonalExpense;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,4 +15,10 @@ public interface PersonalExpenseRepository extends JpaRepository<PersonalExpense
         + "IN :itemIds")
     Long countByMemberIdAndItemIds(@Param("memberId") Long memberId,
         @Param("itemIds") List<Long> itemIds);
+
+//    @Query("SELECT SUM(pe.quantity) FROM PersonalExpense pe "
+//        + "WHERE pe.item.id = :itemId")
+//    Long countQuantityByItemId(@Param("itemId") Long itemId);
+
+    List<PersonalExpense> findAllByItem(Item item);
 }

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -37,6 +37,10 @@ public class PersonalExpenseService {
         for (ItemInfo itemInfo : personalExpense.items()) {
             Item item = getItemIfItemInfoValid(itemInfo);
 
+            personalExpenseRepository.findByMemberAndItem(member, item).ifPresent(data -> {
+                throw new JeongsanException(ErrorType.ALREADY_CHECKED_ITEM);
+            } );
+
             Optional.ofNullable(personalExpenseRepository.findAllByItem(item))
                 .filter(list -> !list.isEmpty())
                 .ifPresentOrElse(

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -1,0 +1,78 @@
+package kappzzang.jeongsan.service;
+
+import java.util.Optional;
+import kappzzang.jeongsan.domain.Item;
+import kappzzang.jeongsan.domain.Member;
+import kappzzang.jeongsan.domain.PersonalExpense;
+import kappzzang.jeongsan.dto.request.SavePersonalExpenseRequest;
+import kappzzang.jeongsan.dto.request.SavePersonalExpenseRequest.ItemInfo;
+import kappzzang.jeongsan.global.common.enumeration.ErrorType;
+import kappzzang.jeongsan.global.exception.JeongsanException;
+import kappzzang.jeongsan.repository.ExpenseRepository;
+import kappzzang.jeongsan.repository.ItemRepository;
+import kappzzang.jeongsan.repository.MemberRepository;
+import kappzzang.jeongsan.repository.PersonalExpenseRepository;
+import kappzzang.jeongsan.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PersonalExpenseService {
+
+    private final MemberRepository memberRepository;
+    private final TeamRepository teamRepository;
+    private final ExpenseRepository expenseRepository;
+    private final ItemRepository itemRepository;
+    private final PersonalExpenseRepository personalExpenseRepository;
+
+    //    @Transactional
+    public void savePersonalExpense(Long memberId, Long teamId, Long expenseId,
+        SavePersonalExpenseRequest personalExpense) {
+
+        Member member = getMemberIfTeamAndExpenseValid(memberId, teamId, expenseId);
+
+        for (ItemInfo itemInfo : personalExpense.items()) {
+            Item item = getItemIfItemInfoValid(itemInfo);
+
+            Optional.ofNullable(personalExpenseRepository.findAllByItem(item))
+                .filter(list -> !list.isEmpty())
+                .ifPresentOrElse(personalExpenses -> saveAndUpdateRecord(),
+                    () -> saveFirstRecord(member, item, itemInfo.quantity(), item.getUnitPrice()));
+        }
+    }
+
+    private Item getItemIfItemInfoValid(ItemInfo itemInfo) {
+        Item item = itemRepository.findById(itemInfo.itemId())
+            .orElseThrow(() -> new JeongsanException(ErrorType.ITEM_NOT_FOUND));
+        if (item.getQuantity() < itemInfo.quantity()) {
+            throw new JeongsanException(ErrorType.INVALID_QUANTITY);
+        }
+        return item;
+    }
+
+    private Member getMemberIfTeamAndExpenseValid(Long memberId, Long teamId, Long expenseId) {
+        teamRepository.findById(teamId)
+            .orElseThrow(() -> new JeongsanException(ErrorType.TEAM_NOT_FOUND));
+        expenseRepository.findById(expenseId)
+            .orElseThrow(() -> new JeongsanException(ErrorType.EXPENSE_NOT_FOUND));
+
+        return memberRepository.findById(memberId)
+            .orElseThrow(() -> new JeongsanException(ErrorType.USER_NOT_FOUND));
+    }
+
+    private void saveAndUpdateRecord() {
+
+    }
+
+    private void saveFirstRecord(Member member, Item item, Integer quantity, Integer itemUnitPrice) {
+        PersonalExpense personalExpense = PersonalExpense.builder().member(member).item(item)
+            .quantity(quantity).totalPrice(itemUnitPrice*quantity).build();
+        personalExpenseRepository.save(personalExpense);
+    }
+
+    //같은 item을 가지고 있는 data 조회, 수량 합 ->
+
+    //item의 총 금액 확인, 나누기
+
+}


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 개인 소비 내역을 저장하는 api 구현

### 🔍 참고 사항
- 트랜잭션(롤백)테스트 추가 예정입니다. 빠른 피드백&수정을 위해 PR 합니다.
( 명백한 예외와 happy path에 대한 작동은 확인 했습니다!)
- 선택한 item에 대한 데이터가 없는 경우(아직 아무도 선택하지 않았거나 본인만 소비한 품목)
   - `item의 unitPrice * 요청 수량` 으로 개인 소비 내역의 totalPrice (personalExpens.totalPrice)를 결정했습니다.
- 선택한 item에 대한 데이터가 있는 경우(다른 사람들이 이미 특정 수량을 선택하여 저장함)
   -  `item의 totalPrice / (존재하는 데이터의 전체 수량 합 + 새로운 요청 수량 = 전체 소비 수량)` * `각자의 소비 수량(personalExpense.quantity)` 으로 개인 소비 내역의 totalPrice (personalExpens.totalPrice)를 결정했습니다.
   - 나누어 떨어지지 않는 경우에는 나머지 금액을 요청 멤버의 금액에 더하도록 했습니다.

### ⚠️ 의논 필요
- 의논(&수정)이 필요한 부분이 많아서 PR로 해결이 안될 것 같습니다🥲
- 한 가지만 언급 하자면,
이전에 나누어 떨어지지 않는 금액은 결제자가 부담하자고 했었는데, 
만약 결제자가 해당 item을 소비하지 않았다면 어떻게 할까요?
- 지금은 위 **참고사항**에 있듯이, 해당 item을 소비했다고 선택한 사람들 중 늦게 선택한 사람이 부담하도록 했습니다.

### 🐞현재 버그
- 현재 버전에 버그가 있다면 작성

### #️⃣ 연관 이슈(Git Close)
- close #86 
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
