### PR TITLE
Feature/issue#78: 지출 상태 변경(송금 대기 -> 완료) 기능 구현

### DIFF
--- a/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
@@ -1,6 +1,8 @@
 package kappzzang.jeongsan.controller;
 
+import jakarta.validation.Valid;
 import kappzzang.jeongsan.controller.docs.ExpenseControllerInterface;
+import kappzzang.jeongsan.dto.request.CompleteExpensesRequest;
 import kappzzang.jeongsan.dto.response.ExpenseResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
@@ -12,7 +14,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,5 +48,14 @@ public class ExpenseController implements ExpenseControllerInterface {
 
         return JeongsanApiResponse.success(SuccessType.EXPENSE_LIST_LOADED,
             expenseService.getExpenses(memberId, teamId, status, isChecked));
+    }
+
+    @Override
+    @PatchMapping("{teamId}")
+    public ResponseEntity<JeongsanApiResponse<Void>> changeExpensesStatusComplete(
+        @Valid @RequestBody CompleteExpensesRequest request,
+        @PathVariable("teamId") Long teamId) {
+        expenseService.completeExpenses(request);
+        return JeongsanApiResponse.success(SuccessType.EXPENSE_STATUS_CHANGE_SUCCESS);
     }
 }

--- a/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
@@ -54,8 +54,9 @@ public class ExpenseController implements ExpenseControllerInterface {
     @PatchMapping("{teamId}")
     public ResponseEntity<JeongsanApiResponse<Void>> changeExpensesStatusComplete(
         @Valid @RequestBody CompleteExpensesRequest request,
-        @PathVariable("teamId") Long teamId) {
-        expenseService.completeExpenses(request);
+        @PathVariable("teamId") Long teamId,
+        @AuthenticationPrincipal Long memberId) {
+        expenseService.completeExpenses(request, teamId, memberId);
         return JeongsanApiResponse.success(SuccessType.EXPENSE_STATUS_CHANGE_SUCCESS);
     }
 }

--- a/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
@@ -39,9 +39,13 @@ public interface ExpenseControllerInterface {
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "지출 상태 변경을 성공"),
         @ApiResponse(responseCode = "400", description =
-            "이미 정산 완료된 지출 존재 (ErrorCode=E400), 아직 진행중인 상태의 지출 존재 (ErrorCode=E400), 요청 목록에 존재하지 않는 지출 포함 (ErrorCode=E400)"),
+            "이미 정산 완료된 지출 존재 (ErrorCode=E400), "
+                + "아직 진행중인 상태의 지출 존재 (ErrorCode=E400), "
+                + "요청 목록에 존재하지 않는 지출 포함 (ErrorCode=E400), "
+                + "요청 목록에 타 모임의 지출이 포함(ErrorCode=E400), "
+                + "요청 목록에 본인이 결제하지 않은 지출이 포함(ErrorCode=E400)"),
     })
     public ResponseEntity<JeongsanApiResponse<Void>> changeExpensesStatusComplete(
-        CompleteExpensesRequest request, Long teamId);
+        CompleteExpensesRequest request, Long teamId, Long memberId);
 
 }

--- a/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kappzzang.jeongsan.dto.request.CompleteExpensesRequest;
 import kappzzang.jeongsan.dto.response.ExpenseResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -30,4 +31,17 @@ public interface ExpenseControllerInterface {
     })
     ResponseEntity<JeongsanApiResponse<ExpenseResponse>> getAllExpenses(Long memberId, Long teamId,
         String state, Boolean isChecked);
+
+    @Operation(summary = "지출 상태 변경(송금 대기 -> 완료) 요청 API", description = "송금 메시지를 전송한 지출의 상태를 완료로 변경하는 API")
+    @Parameters({
+        @Parameter(name = "teamId", description = "상태 변경될 지출들의 모임 ID"),
+    })
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "지출 상태 변경을 성공"),
+        @ApiResponse(responseCode = "400", description =
+            "이미 정산 완료된 지출 존재 (ErrorCode=E400), 아직 진행중인 상태의 지출 존재 (ErrorCode=E400), 요청 목록에 존재하지 않는 지출 포함 (ErrorCode=E400)"),
+    })
+    public ResponseEntity<JeongsanApiResponse<Void>> changeExpensesStatusComplete(
+        CompleteExpensesRequest request, Long teamId);
+
 }

--- a/src/main/java/kappzzang/jeongsan/domain/Expense.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Expense.java
@@ -107,10 +107,10 @@ public class Expense extends BaseEntity {
 
     //서비스단에서 호출 해야 할 경우가 생길 시 public으로 변경
     private void validateOwnerShip(Long teamId, Long memberId) {
-        if (!this.getTeam().getId().equals(teamId)) {
+        if (!this.team.getId().equals(teamId)) {
             throw new JeongsanException(ErrorType.EXPENSE_INVALID_TEAM);
         }
-        if (!this.getPayer().getId().equals(memberId)) {
+        if (!this.payer.getId().equals(memberId)) {
             throw new JeongsanException(ErrorType.EXPENSE_INVALID_PAYER);
         }
     }

--- a/src/main/java/kappzzang/jeongsan/domain/Expense.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Expense.java
@@ -94,14 +94,25 @@ public class Expense extends BaseEntity {
         this.totalPrice = items.stream().mapToInt(Item::getTotalPrice).sum();
     }
 
-    public void changeStatusComplete() {
+    public void changeStatusComplete(Long teamId, Long memberId) {
         if (this.status.equals(Status.COMPLETED)) {
             throw new JeongsanException(ErrorType.EXPENSE_ALREADY_COMPLETED);
         }
         if (this.status.equals(Status.ONGOING)) {
             throw new JeongsanException(ErrorType.EXPENSE_ONGOING);
         }
+        validateOwnerShip(teamId, memberId);
         this.status = Status.COMPLETED;
+    }
+
+    //서비스단에서 호출 해야 할 경우가 생길 시 public으로 변경
+    private void validateOwnerShip(Long teamId, Long memberId) {
+        if (!this.getTeam().getId().equals(teamId)) {
+            throw new JeongsanException(ErrorType.EXPENSE_INVALID_TEAM);
+        }
+        if (!this.getPayer().getId().equals(memberId)) {
+            throw new JeongsanException(ErrorType.EXPENSE_INVALID_PAYER);
+        }
     }
 
     public void changeStatusPending() {

--- a/src/main/java/kappzzang/jeongsan/domain/Expense.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Expense.java
@@ -93,4 +93,19 @@ public class Expense extends BaseEntity {
         }
         this.totalPrice = items.stream().mapToInt(Item::getTotalPrice).sum();
     }
+
+    public void changeStatusComplete() {
+        if (this.status.equals(Status.COMPLETED)) {
+            throw new JeongsanException(ErrorType.EXPENSE_ALREADY_COMPLETED);
+        }
+        if (this.status.equals(Status.ONGOING)) {
+            throw new JeongsanException(ErrorType.EXPENSE_ONGOING);
+        }
+        this.status = Status.COMPLETED;
+    }
+
+    public void changeStatusPending() {
+        this.status = Status.PENDING;
+    }
+
 }

--- a/src/main/java/kappzzang/jeongsan/dto/request/CompleteExpensesRequest.java
+++ b/src/main/java/kappzzang/jeongsan/dto/request/CompleteExpensesRequest.java
@@ -1,0 +1,12 @@
+package kappzzang.jeongsan.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record CompleteExpensesRequest(@NotEmpty List<ExpenseId> expenses) {
+
+    public record ExpenseId(@NotNull Long id) {
+
+    }
+}

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
@@ -16,8 +16,9 @@ public enum ErrorType {
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "E400006", "요청 입력값이 유효하지 않습니다."),
     EXPENSE_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "E400", "이미 정산 완료된 지출입니다."),
     EXPENSE_ONGOING(HttpStatus.BAD_REQUEST, "E400", "아직 진행중인 지출입니다."),
-    EXPENSE_INVALID_IDS(HttpStatus.BAD_REQUEST, "E400",
-        "요청 목록에 존재하지 않는 지출이 포함 되어있습니다."),
+    EXPENSE_NOT_FOUND_ID(HttpStatus.BAD_REQUEST, "E400", "요청 목록에 존재하지 않는 지출이 포함되어 있습니다."),
+    EXPENSE_INVALID_TEAM(HttpStatus.BAD_REQUEST, "E400", "요청 목록에 타 모임의 지출이 포함되어 있습니다."),
+    EXPENSE_INVALID_PAYER(HttpStatus.BAD_REQUEST, "E400", "요청 목록에 본인이 결제하지 않은 지출이 포함되어 있습니다."),
 
     // 401 UNAUTHORIZED
     JWT_SIGNATURE_INVALID(HttpStatus.UNAUTHORIZED, "E401001", "토큰 서명이 유효하지 않습니다."),

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
@@ -14,6 +14,10 @@ public enum ErrorType {
     NOT_INVITED_MEMBER(HttpStatus.BAD_REQUEST, "E400004", "해당 모임에 초대되지 않은 멤버입니다."),
     ALREADY_JOINED_MEMBER(HttpStatus.BAD_REQUEST, "E400005", "이미 모임에 참여한 멤버입니다."),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "E400006", "요청 입력값이 유효하지 않습니다."),
+    EXPENSE_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "E400", "이미 정산 완료된 지출입니다."),
+    EXPENSE_ONGOING(HttpStatus.BAD_REQUEST, "E400", "아직 진행중인 지출입니다."),
+    EXPENSE_INVALID_IDS(HttpStatus.BAD_REQUEST, "E400",
+        "요청 목록에 존재하지 않는 지출이 포함 되어있습니다."),
 
     // 401 UNAUTHORIZED
     JWT_SIGNATURE_INVALID(HttpStatus.UNAUTHORIZED, "E401001", "토큰 서명이 유효하지 않습니다."),

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
@@ -22,7 +22,8 @@ public enum SuccessType {
 
     //204 NO_CONTENT
     TEAM_CLOSED(HttpStatus.NO_CONTENT, "모임이 종료되었습니다."),
-    JOIN_SUCCESS(HttpStatus.NO_CONTENT, "모임 멤버로 참여되었습니다.");
+    JOIN_SUCCESS(HttpStatus.NO_CONTENT, "모임 멤버로 참여되었습니다."),
+    EXPENSE_STATUS_CHANGE_SUCCESS(HttpStatus.NO_CONTENT, "지출 상태 변경을 완료하였습니다.");
 
     private final HttpStatusCode httpStatusCode;
     private final String message;

--- a/src/main/java/kappzzang/jeongsan/repository/ExpenseRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/ExpenseRepository.java
@@ -45,4 +45,11 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
     List<ItemDetail> findItemDetailsByExpenseIdAndMemberId(@Param("expenseId") Long expenseId,
         @Param("memberId") Long memberId);
 
+    @Query("SELECT e FROM Expense e " +
+        "JOIN FETCH e.payer " +
+        "JOIN FETCH e.team " +
+        "JOIN FETCH e.category " +
+        "WHERE e.id IN :ids")
+    List<Expense> findAllByIdWithDetails(List<Long> ids);
+
 }

--- a/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
@@ -9,6 +9,8 @@ import kappzzang.jeongsan.domain.Member;
 import kappzzang.jeongsan.domain.Team;
 import kappzzang.jeongsan.dto.ItemDetail;
 import kappzzang.jeongsan.dto.ItemSummary;
+import kappzzang.jeongsan.dto.request.CompleteExpensesRequest;
+import kappzzang.jeongsan.dto.request.CompleteExpensesRequest.ExpenseId;
 import kappzzang.jeongsan.dto.request.SaveExpenseRequest;
 import kappzzang.jeongsan.dto.response.ExpenseResponse;
 import kappzzang.jeongsan.dto.response.PersonalExpenseDetailResponse;
@@ -94,6 +96,16 @@ public class ExpenseService {
             .build();
 
         return expenseRepository.save(expense).getId();
+    }
+
+    @Transactional
+    public void completeExpenses(CompleteExpensesRequest request) {
+        List<Expense> expenses = expenseRepository.findAllById(request.expenses()
+            .stream().map(ExpenseId::id).toList());
+        if (request.expenses().size() != expenses.size()) {
+            throw new JeongsanException(ErrorType.EXPENSE_INVALID_IDS);
+        }
+        expenses.forEach(Expense::changeStatusComplete);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
@@ -99,13 +99,13 @@ public class ExpenseService {
     }
 
     @Transactional
-    public void completeExpenses(CompleteExpensesRequest request) {
-        List<Expense> expenses = expenseRepository.findAllById(request.expenses()
-            .stream().map(ExpenseId::id).toList());
-        if (request.expenses().size() != expenses.size()) {
-            throw new JeongsanException(ErrorType.EXPENSE_INVALID_IDS);
+    public void completeExpenses(CompleteExpensesRequest request, Long teamId, Long memberId) {
+        List<Expense> expenses = expenseRepository.findAllByIdWithDetails(
+            request.expenses().stream().map(ExpenseId::id).toList());
+        if (expenses.size() != request.expenses().size()) {
+            throw new JeongsanException(ErrorType.EXPENSE_NOT_FOUND_ID);
         }
-        expenses.forEach(Expense::changeStatusComplete);
+        expenses.forEach(expense -> expense.changeStatusComplete(teamId, memberId));
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
@@ -10,10 +10,13 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
 import kappzzang.jeongsan.domain.Category;
 import kappzzang.jeongsan.domain.Expense;
 import kappzzang.jeongsan.domain.Item;
 import kappzzang.jeongsan.dto.ItemDetail;
+import kappzzang.jeongsan.dto.request.CompleteExpensesRequest;
+import kappzzang.jeongsan.dto.request.CompleteExpensesRequest.ExpenseId;
 import kappzzang.jeongsan.dto.response.ExpenseResponse;
 import kappzzang.jeongsan.dto.response.PersonalExpenseDetailResponse;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
@@ -204,6 +207,99 @@ public class ExpenseServiceTest {
         assertThat(response.expenseList()).hasSize(1);
         assertThat(response.totalPrice()).isEqualTo(expense.getTotalPrice());
         assertThat(response.expenseList().getFirst().title()).isEqualTo(expense.getTitle());
+    }
+
+
+    @DisplayName("지출 완료 처리 성공")
+    @Test
+    void completeExpenses_Success() {
+        //given
+        final Long id1 = 1L, id2 = 2L, id3 = 3L;
+        List<Expense> expenses = createExpenses(3);
+        expenses.forEach(Expense::changeStatusPending);
+        List<Long> ids = List.of(id1, id2, id3);
+        CompleteExpensesRequest request = new CompleteExpensesRequest(
+            List.of(new ExpenseId(id1), new ExpenseId(id2), new ExpenseId(id3)));
+        given(
+            mockExpenseRepository.findAllById(ids)).willReturn(
+            expenses);
+
+        //when
+        expenseService.completeExpenses(request);
+
+        //then
+        assertThat(expenses).extracting(Expense::getStatus).containsOnly(Status.COMPLETED);
+        then(mockExpenseRepository).should().findAllById(ids);
+    }
+
+
+    @DisplayName("지출 완료 처리 실패(이미 완료된 지출 존재)")
+    @Test
+    void completeExpenses_AlreadyCompleted_Fail() {
+        //given
+        final Long id1 = 1L, id2 = 2L, id3 = 3L;
+        List<Expense> expenses = createExpenses(3);
+        expenses.forEach(Expense::changeStatusPending);
+        List<Long> ids = List.of(id1, id2, id3);
+        CompleteExpensesRequest request = new CompleteExpensesRequest(
+            List.of(new ExpenseId(id1), new ExpenseId(id2), new ExpenseId(id3)));
+        expenses.get(0).changeStatusComplete();
+        given(
+            mockExpenseRepository.findAllById(ids)).willReturn(
+            expenses);
+
+        //when //then
+        assertThatThrownBy(() -> expenseService.completeExpenses(request)).isInstanceOf(
+                JeongsanException.class)
+            .hasMessage(ErrorType.EXPENSE_ALREADY_COMPLETED.getMessage());
+    }
+
+    @DisplayName("지출 완료 처리 실패(아직 진행중인 지출 존재)")
+    @Test
+    void completeExpenses_StatusIsOngoing_Fail() {
+        //given
+        final Long id1 = 1L, id2 = 2L, id3 = 3L;
+        List<Expense> expenses = createExpenses(3);
+        List<Long> ids = List.of(id1, id2, id3);
+        CompleteExpensesRequest request = new CompleteExpensesRequest(
+            List.of(new ExpenseId(id1), new ExpenseId(id2), new ExpenseId(id3)));
+        given(
+            mockExpenseRepository.findAllById(ids)).willReturn(
+            expenses);
+
+        //when //then
+        assertThatThrownBy(() -> expenseService.completeExpenses(request)).isInstanceOf(
+                JeongsanException.class)
+            .hasMessage(ErrorType.EXPENSE_ONGOING.getMessage());
+    }
+
+    @DisplayName("지출 완료 처리 실패(존재하지 않는 지출이 포함된 요청)")
+    @Test
+    void completeExpenses_NoFoundExpense_Fail() {
+        //given
+        final Long id1 = 1L, id2 = 2L, id3 = 3L;
+        List<Expense> expenses = createExpenses(2);
+        List<Long> ids = List.of(id1, id2, id3);
+        CompleteExpensesRequest request = new CompleteExpensesRequest(
+            List.of(new ExpenseId(id1), new ExpenseId(id2), new ExpenseId(id3)));
+        given(
+            mockExpenseRepository.findAllById(ids)).willReturn(
+            expenses);
+
+        //when //then
+        assertThatThrownBy(() -> expenseService.completeExpenses(request)).isInstanceOf(
+                JeongsanException.class)
+            .hasMessage(ErrorType.EXPENSE_INVALID_IDS.getMessage());
+    }
+
+    private List<Expense> createExpenses(int count) {
+        return IntStream.rangeClosed(1, count)
+            .mapToObj(o -> Expense.builder()
+                .title(TEST_TITLE)
+                .imageUrl(TEST_IMAGE_URL)
+                .items(List.of(new Item("TEST_NAME", 10, 10)))
+                .build())
+            .toList();
     }
 
 }

--- a/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
@@ -15,6 +15,8 @@ import java.util.stream.LongStream;
 import kappzzang.jeongsan.domain.Category;
 import kappzzang.jeongsan.domain.Expense;
 import kappzzang.jeongsan.domain.Item;
+import kappzzang.jeongsan.domain.Member;
+import kappzzang.jeongsan.domain.Team;
 import kappzzang.jeongsan.dto.ItemDetail;
 import kappzzang.jeongsan.dto.request.CompleteExpensesRequest;
 import kappzzang.jeongsan.dto.request.CompleteExpensesRequest.ExpenseId;
@@ -39,6 +41,7 @@ public class ExpenseServiceTest {
 
     private static final Long TEST_EXPENSE_ID = 1L;
     private static final Long TEST_MEMBER_ID = 1L;
+    private static final Long TEST_TEAM_ID = 1L;
     private static final int TEST_EXPENSES_SIZE = 3;
     private static final int DEFAULT_ITEM_PRICE = 10;
     private static final int DEFAULT_ITEM_QUANTITY = 10;
@@ -46,6 +49,8 @@ public class ExpenseServiceTest {
     private static final String TEST_IMAGE_URL = "TEST_IMAGE_URL";
     private final String TEST_PRE_SIGNED_URL = "TEST_PRE_SIGNED_URL";
     private final String TEST_TITLE = "TEST_TITLE";
+    private final Member mockPayer = mock(Member.class);
+    private final Team mockTeam = mock(Team.class);
     private List<Long> expenseIds;
     private CompleteExpensesRequest completeExpensesRequest;
 
@@ -226,16 +231,18 @@ public class ExpenseServiceTest {
         //given
         List<Expense> expenses = createExpenses(TEST_EXPENSES_SIZE);
         expenses.forEach(Expense::changeStatusPending);
+        given(mockTeam.getId()).willReturn(TEST_TEAM_ID);
+        given(mockPayer.getId()).willReturn(TEST_MEMBER_ID);
         given(
-            mockExpenseRepository.findAllById(expenseIds)).willReturn(
+            mockExpenseRepository.findAllByIdWithDetails(expenseIds)).willReturn(
             expenses);
-
         //when
-        expenseService.completeExpenses(completeExpensesRequest);
+        expenseService.completeExpenses(completeExpensesRequest, TEST_TEAM_ID, TEST_MEMBER_ID);
 
         //then
         assertThat(expenses).extracting(Expense::getStatus).containsOnly(Status.COMPLETED);
-        then(mockExpenseRepository).should().findAllById(expenseIds);
+        then(mockExpenseRepository).should()
+            .findAllByIdWithDetails(expenseIds);
     }
 
 
@@ -245,16 +252,36 @@ public class ExpenseServiceTest {
         //given
         List<Expense> expenses = createExpenses(TEST_EXPENSES_SIZE);
         expenses.forEach(Expense::changeStatusPending);
-        expenses.get(0).changeStatusComplete();
+        given(mockTeam.getId()).willReturn(TEST_TEAM_ID);
+        given(mockPayer.getId()).willReturn(TEST_MEMBER_ID);
         given(
-            mockExpenseRepository.findAllById(expenseIds)).willReturn(
+            mockExpenseRepository.findAllByIdWithDetails(expenseIds)).willReturn(
+            expenses);
+        expenses.getFirst().changeStatusComplete(TEST_TEAM_ID, TEST_MEMBER_ID);
+
+        //when //then
+        assertThatThrownBy(
+            () -> expenseService.completeExpenses(completeExpensesRequest, TEST_TEAM_ID,
+                TEST_MEMBER_ID)).isInstanceOf(
+                JeongsanException.class)
+            .hasMessage(ErrorType.EXPENSE_ALREADY_COMPLETED.getMessage());
+    }
+
+    @DisplayName("지출 완료 처리 실패(존재하지 않는 지출 존재)")
+    @Test
+    void completeExpenses_NotFoundExpense_Fail() {
+        //given
+        List<Expense> expenses = createExpenses(TEST_EXPENSES_SIZE - 1);
+        given(
+            mockExpenseRepository.findAllByIdWithDetails(expenseIds)).willReturn(
             expenses);
 
         //when //then
         assertThatThrownBy(
-            () -> expenseService.completeExpenses(completeExpensesRequest)).isInstanceOf(
+            () -> expenseService.completeExpenses(completeExpensesRequest, TEST_TEAM_ID,
+                TEST_MEMBER_ID)).isInstanceOf(
                 JeongsanException.class)
-            .hasMessage(ErrorType.EXPENSE_ALREADY_COMPLETED.getMessage());
+            .hasMessage(ErrorType.EXPENSE_NOT_FOUND_ID.getMessage());
     }
 
     @DisplayName("지출 완료 처리 실패(아직 진행중인 지출 존재)")
@@ -263,35 +290,65 @@ public class ExpenseServiceTest {
         //given
         List<Expense> expenses = createExpenses(TEST_EXPENSES_SIZE);
         given(
-            mockExpenseRepository.findAllById(expenseIds)).willReturn(
+            mockExpenseRepository.findAllByIdWithDetails(expenseIds)).willReturn(
             expenses);
+        given(mockTeam.getId()).willReturn(TEST_TEAM_ID);
+        given(mockPayer.getId()).willReturn(TEST_MEMBER_ID);
 
         //when //then
         assertThatThrownBy(
-            () -> expenseService.completeExpenses(completeExpensesRequest)).isInstanceOf(
+            () -> expenseService.completeExpenses(completeExpensesRequest, TEST_TEAM_ID,
+                TEST_MEMBER_ID)).isInstanceOf(
                 JeongsanException.class)
             .hasMessage(ErrorType.EXPENSE_ONGOING.getMessage());
     }
 
-    @DisplayName("지출 완료 처리 실패(존재하지 않는 지출이 포함된 요청)")
+    @DisplayName("지출 완료 처리 실패(타 모임의 지출이 포함된 요청)")
     @Test
-    void completeExpenses_NoFoundExpense_Fail() {
+    void completeExpenses_AnotherTeam_Fail() {
         //given
-        List<Expense> expenses = createExpenses(TEST_EXPENSES_SIZE - 1);
+        final Long INVALID_TEAM_ID = 2L;
+        List<Expense> expenses = createExpenses(TEST_EXPENSES_SIZE);
+        expenses.forEach(Expense::changeStatusPending);
         given(
-            mockExpenseRepository.findAllById(expenseIds)).willReturn(
+            mockExpenseRepository.findAllByIdWithDetails(expenseIds)).willReturn(
             expenses);
+        given(mockTeam.getId()).willReturn(INVALID_TEAM_ID);
+        //when //then
+        assertThatThrownBy(
+            () -> expenseService.completeExpenses(completeExpensesRequest, TEST_TEAM_ID,
+                TEST_MEMBER_ID)).isInstanceOf(
+                JeongsanException.class)
+            .hasMessage(ErrorType.EXPENSE_INVALID_TEAM.getMessage());
+    }
+
+
+    @DisplayName("지출 완료 처리 실패(자신이 결제하지 않은 지출이 포함된 요청)")
+    @Test
+    void completeExpenses_AnotherPayer_Fail() {
+        //given
+        final Long INVALID_MEMBER_ID = 2L;
+        List<Expense> expenses = createExpenses(TEST_EXPENSES_SIZE);
+        expenses.forEach(Expense::changeStatusPending);
+        given(
+            mockExpenseRepository.findAllByIdWithDetails(expenseIds)).willReturn(
+            expenses);
+        given(mockTeam.getId()).willReturn(TEST_TEAM_ID);
+        given(mockPayer.getId()).willReturn(INVALID_MEMBER_ID);
 
         //when //then
         assertThatThrownBy(
-            () -> expenseService.completeExpenses(completeExpensesRequest)).isInstanceOf(
+            () -> expenseService.completeExpenses(completeExpensesRequest, TEST_TEAM_ID,
+                TEST_MEMBER_ID)).isInstanceOf(
                 JeongsanException.class)
-            .hasMessage(ErrorType.EXPENSE_INVALID_IDS.getMessage());
+            .hasMessage(ErrorType.EXPENSE_INVALID_PAYER.getMessage());
     }
 
     private List<Expense> createExpenses(int count) {
         return IntStream.rangeClosed(1, count)
             .mapToObj(o -> Expense.builder()
+                .team(mockTeam)
+                .member(mockPayer)
                 .title(TEST_TITLE)
                 .imageUrl(TEST_IMAGE_URL)
                 .items(

--- a/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 import kappzzang.jeongsan.domain.Category;
 import kappzzang.jeongsan.domain.Expense;
 import kappzzang.jeongsan.domain.Item;
@@ -38,9 +39,15 @@ public class ExpenseServiceTest {
 
     private static final Long TEST_EXPENSE_ID = 1L;
     private static final Long TEST_MEMBER_ID = 1L;
+    private static final int TEST_EXPENSES_SIZE = 3;
+    private static final int DEFAULT_ITEM_PRICE = 10;
+    private static final int DEFAULT_ITEM_QUANTITY = 10;
+    private static final String DEFAULT_ITEM_NAME = "DEFAULT_ITEM_NAME";
     private static final String TEST_IMAGE_URL = "TEST_IMAGE_URL";
     private final String TEST_PRE_SIGNED_URL = "TEST_PRE_SIGNED_URL";
     private final String TEST_TITLE = "TEST_TITLE";
+    private List<Long> expenseIds;
+    private CompleteExpensesRequest completeExpensesRequest;
 
     @Mock
     private ImageStorageService mockImageStorageService;
@@ -66,6 +73,9 @@ public class ExpenseServiceTest {
             .imageUrl(TEST_IMAGE_URL)
             .items(List.of(new Item("TEST_NAME", 10, 10)))
             .build();
+        expenseIds = LongStream.rangeClosed(1, TEST_EXPENSES_SIZE).boxed().toList();
+        completeExpensesRequest = new CompleteExpensesRequest(
+            expenseIds.stream().map(ExpenseId::new).toList());
     }
 
     @Test
@@ -214,22 +224,18 @@ public class ExpenseServiceTest {
     @Test
     void completeExpenses_Success() {
         //given
-        final Long id1 = 1L, id2 = 2L, id3 = 3L;
-        List<Expense> expenses = createExpenses(3);
+        List<Expense> expenses = createExpenses(TEST_EXPENSES_SIZE);
         expenses.forEach(Expense::changeStatusPending);
-        List<Long> ids = List.of(id1, id2, id3);
-        CompleteExpensesRequest request = new CompleteExpensesRequest(
-            List.of(new ExpenseId(id1), new ExpenseId(id2), new ExpenseId(id3)));
         given(
-            mockExpenseRepository.findAllById(ids)).willReturn(
+            mockExpenseRepository.findAllById(expenseIds)).willReturn(
             expenses);
 
         //when
-        expenseService.completeExpenses(request);
+        expenseService.completeExpenses(completeExpensesRequest);
 
         //then
         assertThat(expenses).extracting(Expense::getStatus).containsOnly(Status.COMPLETED);
-        then(mockExpenseRepository).should().findAllById(ids);
+        then(mockExpenseRepository).should().findAllById(expenseIds);
     }
 
 
@@ -237,19 +243,16 @@ public class ExpenseServiceTest {
     @Test
     void completeExpenses_AlreadyCompleted_Fail() {
         //given
-        final Long id1 = 1L, id2 = 2L, id3 = 3L;
-        List<Expense> expenses = createExpenses(3);
+        List<Expense> expenses = createExpenses(TEST_EXPENSES_SIZE);
         expenses.forEach(Expense::changeStatusPending);
-        List<Long> ids = List.of(id1, id2, id3);
-        CompleteExpensesRequest request = new CompleteExpensesRequest(
-            List.of(new ExpenseId(id1), new ExpenseId(id2), new ExpenseId(id3)));
         expenses.get(0).changeStatusComplete();
         given(
-            mockExpenseRepository.findAllById(ids)).willReturn(
+            mockExpenseRepository.findAllById(expenseIds)).willReturn(
             expenses);
 
         //when //then
-        assertThatThrownBy(() -> expenseService.completeExpenses(request)).isInstanceOf(
+        assertThatThrownBy(
+            () -> expenseService.completeExpenses(completeExpensesRequest)).isInstanceOf(
                 JeongsanException.class)
             .hasMessage(ErrorType.EXPENSE_ALREADY_COMPLETED.getMessage());
     }
@@ -258,17 +261,14 @@ public class ExpenseServiceTest {
     @Test
     void completeExpenses_StatusIsOngoing_Fail() {
         //given
-        final Long id1 = 1L, id2 = 2L, id3 = 3L;
-        List<Expense> expenses = createExpenses(3);
-        List<Long> ids = List.of(id1, id2, id3);
-        CompleteExpensesRequest request = new CompleteExpensesRequest(
-            List.of(new ExpenseId(id1), new ExpenseId(id2), new ExpenseId(id3)));
+        List<Expense> expenses = createExpenses(TEST_EXPENSES_SIZE);
         given(
-            mockExpenseRepository.findAllById(ids)).willReturn(
+            mockExpenseRepository.findAllById(expenseIds)).willReturn(
             expenses);
 
         //when //then
-        assertThatThrownBy(() -> expenseService.completeExpenses(request)).isInstanceOf(
+        assertThatThrownBy(
+            () -> expenseService.completeExpenses(completeExpensesRequest)).isInstanceOf(
                 JeongsanException.class)
             .hasMessage(ErrorType.EXPENSE_ONGOING.getMessage());
     }
@@ -277,17 +277,14 @@ public class ExpenseServiceTest {
     @Test
     void completeExpenses_NoFoundExpense_Fail() {
         //given
-        final Long id1 = 1L, id2 = 2L, id3 = 3L;
-        List<Expense> expenses = createExpenses(2);
-        List<Long> ids = List.of(id1, id2, id3);
-        CompleteExpensesRequest request = new CompleteExpensesRequest(
-            List.of(new ExpenseId(id1), new ExpenseId(id2), new ExpenseId(id3)));
+        List<Expense> expenses = createExpenses(TEST_EXPENSES_SIZE - 1);
         given(
-            mockExpenseRepository.findAllById(ids)).willReturn(
+            mockExpenseRepository.findAllById(expenseIds)).willReturn(
             expenses);
 
         //when //then
-        assertThatThrownBy(() -> expenseService.completeExpenses(request)).isInstanceOf(
+        assertThatThrownBy(
+            () -> expenseService.completeExpenses(completeExpensesRequest)).isInstanceOf(
                 JeongsanException.class)
             .hasMessage(ErrorType.EXPENSE_INVALID_IDS.getMessage());
     }
@@ -297,7 +294,8 @@ public class ExpenseServiceTest {
             .mapToObj(o -> Expense.builder()
                 .title(TEST_TITLE)
                 .imageUrl(TEST_IMAGE_URL)
-                .items(List.of(new Item("TEST_NAME", 10, 10)))
+                .items(
+                    List.of(new Item(DEFAULT_ITEM_NAME, DEFAULT_ITEM_QUANTITY, DEFAULT_ITEM_PRICE)))
                 .build())
             .toList();
     }


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 지출 정산 상태 변경(송금 대기 -> 완료) 기능 구현
- 테스트 코드 작성

### 🔍 참고 사항
- 9주차 주간 회의때에 변경된 API 명세 기준으로 기능 구현하였습니다.
- `Expense`의 `changeStatusPending()`메서드의 경우 테스트를 위해 단순 구현하였습니다.
- 이후 `changeStatusPending()` 변경 시 ExpenseServiceTest가 작동하지 않게 된다면 전체 코드 주석 처리 부탁드립니다.

### ⚠️ 의논 필요
- X

### 🐞현재 버그
- X

### #️⃣ 연관 이슈(Git Close)
- close #78 
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
