### PR TITLE
Feature/issue#86 : 개인 소비 내역 저장 API 구현

### DIFF
--- a/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
@@ -3,6 +3,7 @@ package kappzzang.jeongsan.controller;
 import jakarta.validation.Valid;
 import kappzzang.jeongsan.controller.docs.ExpenseControllerInterface;
 import kappzzang.jeongsan.dto.request.CompleteExpensesRequest;
+import kappzzang.jeongsan.dto.request.SavePersonalExpenseRequest;
 import kappzzang.jeongsan.dto.response.ExpenseResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
@@ -10,12 +11,14 @@ import kappzzang.jeongsan.global.common.enumeration.Status;
 import kappzzang.jeongsan.global.common.enumeration.SuccessType;
 import kappzzang.jeongsan.global.exception.JeongsanException;
 import kappzzang.jeongsan.service.ExpenseService;
+import kappzzang.jeongsan.service.PersonalExpenseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -27,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ExpenseController implements ExpenseControllerInterface {
 
     private final ExpenseService expenseService;
+    private final PersonalExpenseService personalExpenseService;
 
     @Override
     @GetMapping("{teamId}")
@@ -58,5 +62,13 @@ public class ExpenseController implements ExpenseControllerInterface {
         @AuthenticationPrincipal Long memberId) {
         expenseService.completeExpenses(request, teamId, memberId);
         return JeongsanApiResponse.success(SuccessType.EXPENSE_STATUS_CHANGE_SUCCESS);
+    }
+
+    @PostMapping("/personal/{teamId}/{expenseId}")
+    public ResponseEntity<JeongsanApiResponse<Void>> savePersonalExpense(
+            @PathVariable("teamId") Long teamId, @PathVariable("expenseId") Long expenseId,
+            @Valid @RequestBody SavePersonalExpenseRequest personalExpense) {
+        personalExpenseService.savePersonalExpense(1L, teamId, expenseId, personalExpense);
+        return JeongsanApiResponse.success(SuccessType.PERSONAL_EXPENSE_SAVED);
     }
 }

--- a/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
@@ -64,6 +64,7 @@ public class ExpenseController implements ExpenseControllerInterface {
         return JeongsanApiResponse.success(SuccessType.EXPENSE_STATUS_CHANGE_SUCCESS);
     }
 
+    @Override
     @PostMapping("/personal/{teamId}/{expenseId}/{memberId}")
     public ResponseEntity<JeongsanApiResponse<Void>> savePersonalExpense(
         @PathVariable("teamId") Long teamId, @PathVariable("expenseId") Long expenseId,

--- a/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
@@ -64,11 +64,12 @@ public class ExpenseController implements ExpenseControllerInterface {
         return JeongsanApiResponse.success(SuccessType.EXPENSE_STATUS_CHANGE_SUCCESS);
     }
 
-    @PostMapping("/personal/{teamId}/{expenseId}")
+    @PostMapping("/personal/{teamId}/{expenseId}/{memberId}")
     public ResponseEntity<JeongsanApiResponse<Void>> savePersonalExpense(
-            @PathVariable("teamId") Long teamId, @PathVariable("expenseId") Long expenseId,
-            @Valid @RequestBody SavePersonalExpenseRequest personalExpense) {
-        personalExpenseService.savePersonalExpense(1L, teamId, expenseId, personalExpense);
+        @PathVariable("teamId") Long teamId, @PathVariable("expenseId") Long expenseId,
+        @PathVariable("memberId") Long memberId,
+        @Valid @RequestBody SavePersonalExpenseRequest personalExpense) {
+        personalExpenseService.savePersonalExpense(memberId, teamId, expenseId, personalExpense);
         return JeongsanApiResponse.success(SuccessType.PERSONAL_EXPENSE_SAVED);
     }
 }

--- a/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
@@ -65,10 +65,10 @@ public class ExpenseController implements ExpenseControllerInterface {
     }
 
     @Override
-    @PostMapping("/personal/{teamId}/{expenseId}/{memberId}")
+    @PostMapping("/personal/{teamId}/{expenseId}")
     public ResponseEntity<JeongsanApiResponse<Void>> savePersonalExpense(
         @PathVariable("teamId") Long teamId, @PathVariable("expenseId") Long expenseId,
-        @PathVariable("memberId") Long memberId,
+        @AuthenticationPrincipal Long memberId,
         @Valid @RequestBody SavePersonalExpenseRequest personalExpense) {
         personalExpenseService.savePersonalExpense(memberId, teamId, expenseId, personalExpense);
         return JeongsanApiResponse.success(SuccessType.PERSONAL_EXPENSE_SAVED);

--- a/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
@@ -62,6 +62,6 @@ public interface ExpenseControllerInterface {
         @ApiResponse(responseCode = "404", description =
             "`teamId`, `expenseId`, `itemId`에 해당하는 데이터가 존재하지 않음 (ErrorCode-E404002, E404004, E404)", content = @Content)
     })
-    ResponseEntity<JeongsanApiResponse<Void>> savePersonalExpense(Long memberId, Long teamId,
-        Long expenseId, SavePersonalExpenseRequest personalExpense);
+    ResponseEntity<JeongsanApiResponse<Void>> savePersonalExpense(Long teamId,
+        Long expenseId, Long memberId, SavePersonalExpenseRequest personalExpense);
 }

--- a/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
@@ -56,9 +56,11 @@ public interface ExpenseControllerInterface {
     })
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "개인 소비 내역 저장 성공", content = @Content),
-        @ApiResponse(responseCode = "400", description = "아이템 quantity 보다 많은 선택 수량 (ErrorCode=E400)", content = @Content),
-        @ApiResponse(responseCode = "400", description = "이전에 선택하여 저장 한 아이템이 포함된 요청 (ErrorCode-E400)", content = @Content),
-        @ApiResponse(responseCode = "404", description = "`teamId`, `expenseId`, `itemId`에 해당하는 데이터가 존재하지 않음 (ErrorCode-E404002, 004, 00?)", content = @Content)
+        @ApiResponse(responseCode = "400", description =
+            "이전에 선택하여 저장 한 아이템이 포함된 요청 (ErrorCode-E400), "
+                + "아이템 quantity 보다 많은 선택 수량 (ErrorCode=E400)", content = @Content),
+        @ApiResponse(responseCode = "404", description =
+            "`teamId`, `expenseId`, `itemId`에 해당하는 데이터가 존재하지 않음 (ErrorCode-E404002, E404004, E404)", content = @Content)
     })
     ResponseEntity<JeongsanApiResponse<Void>> savePersonalExpense(Long memberId, Long teamId,
         Long expenseId, SavePersonalExpenseRequest personalExpense);

--- a/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kappzzang.jeongsan.dto.request.CompleteExpensesRequest;
+import kappzzang.jeongsan.dto.request.SavePersonalExpenseRequest;
 import kappzzang.jeongsan.dto.response.ExpenseResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -48,4 +49,17 @@ public interface ExpenseControllerInterface {
     public ResponseEntity<JeongsanApiResponse<Void>> changeExpensesStatusComplete(
         CompleteExpensesRequest request, Long teamId, Long memberId);
 
+    @Operation(summary = "지출 내역 저장(선택 완료) API", description = "개인이 소비한 품목(아이템)을 선택하여 저장하는 API")
+    @Parameters({
+        @Parameter(name = "teamId", description = "요청 멤버가 속한 모임의 ID"),
+        @Parameter(name = "expenseId", description = "선택한 아이템이 속한 지출의 ID"),
+    })
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "개인 소비 내역 저장 성공", content = @Content),
+        @ApiResponse(responseCode = "400", description = "아이템 quantity 보다 많은 선택 수량 (ErrorCode=E400)", content = @Content),
+        @ApiResponse(responseCode = "400", description = "이전에 선택하여 저장 한 아이템이 포함된 요청 (ErrorCode-E400)", content = @Content),
+        @ApiResponse(responseCode = "404", description = "`teamId`, `expenseId`, `itemId`에 해당하는 데이터가 존재하지 않음 (ErrorCode-E404002, 004, 00?)", content = @Content)
+    })
+    ResponseEntity<JeongsanApiResponse<Void>> savePersonalExpense(Long memberId, Long teamId,
+        Long expenseId, SavePersonalExpenseRequest personalExpense);
 }

--- a/src/main/java/kappzzang/jeongsan/domain/PersonalExpense.java
+++ b/src/main/java/kappzzang/jeongsan/domain/PersonalExpense.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.criteria.CriteriaBuilder.In;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
 import kappzzang.jeongsan.global.exception.JeongsanException;
 import lombok.Builder;
@@ -36,6 +37,14 @@ public class PersonalExpense extends BaseEntity {
 
     @Column(nullable = false)
     private Integer totalPrice;
+
+    @Builder(toBuilder = true)
+    public PersonalExpense(Member member, Item item, Integer quantity, Integer totalPrice) {
+        this.member = member;
+        this.item = item;
+        this.quantity = quantity;
+        this.totalPrice = totalPrice;
+    }
 
     @Builder
     public PersonalExpense(Member member, Integer quantity, Item item) {

--- a/src/main/java/kappzzang/jeongsan/domain/PersonalExpense.java
+++ b/src/main/java/kappzzang/jeongsan/domain/PersonalExpense.java
@@ -37,7 +37,7 @@ public class PersonalExpense extends BaseEntity {
     @Column(nullable = false)
     private Integer totalPrice;
 
-    @Builder(toBuilder = true)
+    @Builder
     public PersonalExpense(Member member, Item item, Integer quantity, Integer totalPrice) {
         this.member = member;
         this.item = item;
@@ -60,4 +60,7 @@ public class PersonalExpense extends BaseEntity {
         this.totalPrice = this.quantity * this.item.getUnitPrice();
     }
 
+    public void updateTotalPrice(int newTotalPrice) {
+        this.totalPrice = newTotalPrice;
+    }
 }

--- a/src/main/java/kappzzang/jeongsan/domain/PersonalExpense.java
+++ b/src/main/java/kappzzang/jeongsan/domain/PersonalExpense.java
@@ -8,7 +8,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.criteria.CriteriaBuilder.In;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
 import kappzzang.jeongsan.global.exception.JeongsanException;
 import lombok.Builder;

--- a/src/main/java/kappzzang/jeongsan/dto/request/SavePersonalExpenseRequest.java
+++ b/src/main/java/kappzzang/jeongsan/dto/request/SavePersonalExpenseRequest.java
@@ -1,12 +1,13 @@
 package kappzzang.jeongsan.dto.request;
 
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
 
 public record SavePersonalExpenseRequest(@NotEmpty List<ItemInfo> items) {
 
-    public record ItemInfo(@NotEmpty Long itemId, @Positive Integer quantity) {
+    public record ItemInfo(@NotNull Long itemId, @Positive Integer quantity) {
 
     }
 }

--- a/src/main/java/kappzzang/jeongsan/dto/request/SavePersonalExpenseRequest.java
+++ b/src/main/java/kappzzang/jeongsan/dto/request/SavePersonalExpenseRequest.java
@@ -1,0 +1,12 @@
+package kappzzang.jeongsan.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+
+public record SavePersonalExpenseRequest(@NotEmpty List<ItemInfo> items) {
+
+    public record ItemInfo(@NotEmpty Long itemId, @Positive Integer quantity) {
+
+    }
+}

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
@@ -21,6 +21,7 @@ public enum ErrorType {
     EXPENSE_INVALID_PAYER(HttpStatus.BAD_REQUEST, "E400", "요청 목록에 본인이 결제하지 않은 지출이 포함되어 있습니다."),
     INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "E400", "잘못된 quantity 값 요청입니다."),
     ALREADY_CHECKED_ITEM(HttpStatus.BAD_REQUEST, "E400", "이미 선택 완료 한 품목이 포함된 요청입니다."),
+    EXPENSE_NOT_IN_TEAM(HttpStatus.BAD_REQUEST, "E400", "팀에 속하지 않은 지출에 대한 요청입니다."),
 
     // 401 UNAUTHORIZED
     JWT_SIGNATURE_INVALID(HttpStatus.UNAUTHORIZED, "E401001", "토큰 서명이 유효하지 않습니다."),
@@ -38,6 +39,8 @@ public enum ErrorType {
     INVITATION_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "E404006", "초대 현황을 찾을 수 없습니다."),
     KAKAO_PAY_LINK_NOT_FOUND(HttpStatus.NOT_FOUND, "E404", "카카오 페이 송금 링크를 찾을 수 없습니다."),
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "E404", "아이템(영수증 품목)을 찾을 수 없습니다."),
+    TEAM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "E404", "팀 멤버를 찾을 수 없습니다."),
+
 
     //408 REQUEST_TIMEOUT
     EXTERNAL_API_REQUEST_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "E408001", "외부 API 요청 시간이 초과되었습니다."),

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
@@ -20,6 +20,7 @@ public enum ErrorType {
     EXPENSE_INVALID_TEAM(HttpStatus.BAD_REQUEST, "E400", "요청 목록에 타 모임의 지출이 포함되어 있습니다."),
     EXPENSE_INVALID_PAYER(HttpStatus.BAD_REQUEST, "E400", "요청 목록에 본인이 결제하지 않은 지출이 포함되어 있습니다."),
     INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "E400", "잘못된 quantity 값 요청입니다."),
+    ALREADY_CHECKED_ITEM(HttpStatus.BAD_REQUEST, "E400", "이미 선택 완료 한 품목이 포함된 요청입니다."),
 
     // 401 UNAUTHORIZED
     JWT_SIGNATURE_INVALID(HttpStatus.UNAUTHORIZED, "E401001", "토큰 서명이 유효하지 않습니다."),

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
@@ -19,6 +19,7 @@ public enum ErrorType {
     EXPENSE_NOT_FOUND_ID(HttpStatus.BAD_REQUEST, "E400", "요청 목록에 존재하지 않는 지출이 포함되어 있습니다."),
     EXPENSE_INVALID_TEAM(HttpStatus.BAD_REQUEST, "E400", "요청 목록에 타 모임의 지출이 포함되어 있습니다."),
     EXPENSE_INVALID_PAYER(HttpStatus.BAD_REQUEST, "E400", "요청 목록에 본인이 결제하지 않은 지출이 포함되어 있습니다."),
+    INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "E400", "잘못된 quantity 값 요청입니다."),
 
     // 401 UNAUTHORIZED
     JWT_SIGNATURE_INVALID(HttpStatus.UNAUTHORIZED, "E401001", "토큰 서명이 유효하지 않습니다."),
@@ -34,6 +35,7 @@ public enum ErrorType {
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "E404003", "카테고리을 찾을 수 없습니다."),
     EXPENSE_NOT_FOUND(HttpStatus.NOT_FOUND, "E404004", "지출을 찾을 수 없습니다."),
     INVITATION_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "E404006", "초대 현황을 찾을 수 없습니다."),
+    ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "E404", "아이템(영수증 품목)을 찾을 수 없습니다."),
 
     //408 REQUEST_TIMEOUT
     EXTERNAL_API_REQUEST_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "E408001", "외부 API 요청 시간이 초과되었습니다."),

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
@@ -14,6 +14,7 @@ public enum SuccessType {
     PERSONAL_EXPENSE_LOADED(HttpStatus.OK, "개인 지출 목록을 불러오는 데 성공했습니다."),
     INVITATION_STATUS_LOADED(HttpStatus.OK, "모임의 멤버 초대 현황을 불러오는 데 성공했습니다."),
     ACCESS_TOKEN_REISSUED(HttpStatus.OK, "액세스 토큰이 재발급되었습니다."),
+    PERSONAL_EXPENSE_SAVED(HttpStatus.OK, "개인 소비 내역이 저장되었습니다."),
 
     // 201 CREATED
     TEAM_CREATED(HttpStatus.CREATED, "모임이 생성되었습니다."),

--- a/src/main/java/kappzzang/jeongsan/repository/PersonalExpenseRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/PersonalExpenseRepository.java
@@ -19,5 +19,6 @@ public interface PersonalExpenseRepository extends JpaRepository<PersonalExpense
         @Param("itemIds") List<Long> itemIds);
 
     List<PersonalExpense> findAllByItem(Item item);
+
     Optional<PersonalExpense> findByMemberAndItem(Member member, Item item);
 }

--- a/src/main/java/kappzzang/jeongsan/repository/PersonalExpenseRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/PersonalExpenseRepository.java
@@ -1,7 +1,9 @@
 package kappzzang.jeongsan.repository;
 
 import java.util.List;
+import java.util.Optional;
 import kappzzang.jeongsan.domain.Item;
+import kappzzang.jeongsan.domain.Member;
 import kappzzang.jeongsan.domain.PersonalExpense;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -17,4 +19,5 @@ public interface PersonalExpenseRepository extends JpaRepository<PersonalExpense
         @Param("itemIds") List<Long> itemIds);
 
     List<PersonalExpense> findAllByItem(Item item);
+    Optional<PersonalExpense> findByMemberAndItem(Member member, Item item);
 }

--- a/src/main/java/kappzzang/jeongsan/repository/PersonalExpenseRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/PersonalExpenseRepository.java
@@ -1,6 +1,7 @@
 package kappzzang.jeongsan.repository;
 
 import java.util.List;
+import kappzzang.jeongsan.domain.Item;
 import kappzzang.jeongsan.domain.PersonalExpense;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,4 +15,6 @@ public interface PersonalExpenseRepository extends JpaRepository<PersonalExpense
         + "IN :itemIds")
     Long countByMemberIdAndItemIds(@Param("memberId") Long memberId,
         @Param("itemIds") List<Long> itemIds);
+
+    List<PersonalExpense> findAllByItem(Item item);
 }

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -37,6 +37,10 @@ public class PersonalExpenseService {
         for (ItemInfo itemInfo : personalExpense.items()) {
             Item item = getItemIfItemInfoValid(itemInfo);
 
+            personalExpenseRepository.findByMemberAndItem(member, item).ifPresent(data -> {
+                throw new JeongsanException(ErrorType.ALREADY_CHECKED_ITEM);
+            } );
+
             Optional.ofNullable(personalExpenseRepository.findAllByItem(item))
                 .filter(list -> !list.isEmpty())
                 .ifPresentOrElse(

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -1,0 +1,78 @@
+package kappzzang.jeongsan.service;
+
+import java.util.Optional;
+import kappzzang.jeongsan.domain.Item;
+import kappzzang.jeongsan.domain.Member;
+import kappzzang.jeongsan.domain.PersonalExpense;
+import kappzzang.jeongsan.dto.request.SavePersonalExpenseRequest;
+import kappzzang.jeongsan.dto.request.SavePersonalExpenseRequest.ItemInfo;
+import kappzzang.jeongsan.global.common.enumeration.ErrorType;
+import kappzzang.jeongsan.global.exception.JeongsanException;
+import kappzzang.jeongsan.repository.ExpenseRepository;
+import kappzzang.jeongsan.repository.ItemRepository;
+import kappzzang.jeongsan.repository.MemberRepository;
+import kappzzang.jeongsan.repository.PersonalExpenseRepository;
+import kappzzang.jeongsan.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PersonalExpenseService {
+
+    private final MemberRepository memberRepository;
+    private final TeamRepository teamRepository;
+    private final ExpenseRepository expenseRepository;
+    private final ItemRepository itemRepository;
+    private final PersonalExpenseRepository personalExpenseRepository;
+
+    //    @Transactional
+    public void savePersonalExpense(Long memberId, Long teamId, Long expenseId,
+        SavePersonalExpenseRequest personalExpense) {
+
+        Member member = getMemberIfTeamAndExpenseValid(memberId, teamId, expenseId);
+
+        for (ItemInfo itemInfo : personalExpense.items()) {
+            Item item = getItemIfItemInfoValid(itemInfo);
+
+            Optional.ofNullable(personalExpenseRepository.findAllByItem(item))
+                .filter(list -> !list.isEmpty())
+                .ifPresentOrElse(personalExpenses -> saveAndUpdateRecord(),
+                    () -> saveFirstRecord(member, item, itemInfo.quantity(), item.getUnitPrice()));
+        }
+    }
+
+    private Item getItemIfItemInfoValid(ItemInfo itemInfo) {
+        Item item = itemRepository.findById(itemInfo.itemId())
+            .orElseThrow(() -> new JeongsanException(ErrorType.ITEM_NOT_FOUND));
+        if (item.getQuantity() < itemInfo.quantity()) {
+            throw new JeongsanException(ErrorType.INVALID_QUANTITY);
+        }
+        return item;
+    }
+
+    private Member getMemberIfTeamAndExpenseValid(Long memberId, Long teamId, Long expenseId) {
+        teamRepository.findById(teamId)
+            .orElseThrow(() -> new JeongsanException(ErrorType.TEAM_NOT_FOUND));
+        expenseRepository.findById(expenseId)
+            .orElseThrow(() -> new JeongsanException(ErrorType.EXPENSE_NOT_FOUND));
+
+        return memberRepository.findById(memberId)
+            .orElseThrow(() -> new JeongsanException(ErrorType.USER_NOT_FOUND));
+    }
+
+    private void saveAndUpdateRecord() {
+
+    }
+
+    private void saveFirstRecord(Member member, Item item, Integer quantity, Integer itemUnitPrice) {
+        PersonalExpense personalExpense = PersonalExpense.builder().member(member).item(item)
+            .quantity(quantity).totalPrice(itemUnitPrice*quantity).build();
+        personalExpenseRepository.save(personalExpense);
+    }
+
+    //같은 item을 가지고 있는 data 조회, 수량 합 ->
+
+    //item의 총 금액 확인, 나누기
+
+}

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -2,7 +2,6 @@ package kappzzang.jeongsan.service;
 
 import jakarta.transaction.Transactional;
 import java.util.List;
-import java.util.Optional;
 import kappzzang.jeongsan.domain.Item;
 import kappzzang.jeongsan.domain.Member;
 import kappzzang.jeongsan.domain.PersonalExpense;
@@ -39,14 +38,14 @@ public class PersonalExpenseService {
 
             personalExpenseRepository.findByMemberAndItem(member, item).ifPresent(data -> {
                 throw new JeongsanException(ErrorType.ALREADY_CHECKED_ITEM);
-            } );
+            });
 
-            Optional.ofNullable(personalExpenseRepository.findAllByItem(item))
-                .filter(list -> !list.isEmpty())
-                .ifPresentOrElse(
-                    personalExpenses -> updateAndSaveRecords(personalExpenses, item,
-                        itemInfo, member),
-                    () -> saveFirstRecord(member, item, itemInfo.quantity()));
+            List<PersonalExpense> personalExpenses = personalExpenseRepository.findAllByItem(item);
+            if (personalExpenses.isEmpty()) {
+                saveFirstRecord(member, item, itemInfo.quantity());
+            } else {
+                updateAndSaveRecords(personalExpenses, item, itemInfo, member);
+            }
         }
     }
 
@@ -81,12 +80,12 @@ public class PersonalExpenseService {
         personalExpenses.forEach(personalExpense -> {
             PersonalExpense updatedPersonalExpense = personalExpense.toBuilder()
                 .totalPrice(newTotalPrice * personalExpense.getQuantity()).build();
-            personalExpenseRepository.save(updatedPersonalExpense);
+            savePersonalExpense(updatedPersonalExpense);
         });
 
         PersonalExpense newPersonalExpense = PersonalExpense.builder().member(member).item(item)
             .quantity(itemInfo.quantity()).totalPrice(requestedMemberPrice).build();
-        personalExpenseRepository.save(newPersonalExpense);
+        savePersonalExpense(newPersonalExpense);
     }
 
     private void saveFirstRecord(Member member, Item item, Integer quantity) {
@@ -95,9 +94,14 @@ public class PersonalExpenseService {
         personalExpenseRepository.save(personalExpense);
     }
 
-    private int calculateRequestMemberPrice(int totalPrice, int totalQuantity, int requestQuantity) {
+    private int calculateRequestMemberPrice(int totalPrice, int totalQuantity,
+        int requestQuantity) {
         int newTotalPrice = (totalPrice / totalQuantity) * requestQuantity;
         int remainder = totalPrice % totalQuantity;
-        return (remainder == 0) ? newTotalPrice : newTotalPrice + remainder;
+        return newTotalPrice + remainder;
+    }
+
+    private void savePersonalExpense(PersonalExpense personalExpense) {
+        personalExpenseRepository.save(personalExpense);
     }
 }

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -70,10 +70,10 @@ public class PersonalExpenseService {
     private void updateAndSaveRecords(List<PersonalExpense> personalExpenses, Item item,
         ItemInfo itemInfo, Member member) {
 
-        int totalQuantity = personalExpenses.stream().mapToInt(PersonalExpense::getQuantity)
-            .sum() + itemInfo.quantity();
-        int requestedMemberPrice = calculateRequestMemberPrice(item.getTotalPrice(),
-            totalQuantity, itemInfo.quantity());
+        int totalQuantity = personalExpenses.stream().mapToInt(PersonalExpense::getQuantity).sum()
+            + itemInfo.quantity();
+        int requestedMemberPrice = calculateRequestMemberPrice(item.getTotalPrice(), totalQuantity,
+            itemInfo.quantity());
         int newPersonalUnitPrice = item.getTotalPrice() / totalQuantity;
 
         updateExistingPersonalExpenses(personalExpenses, newPersonalUnitPrice);

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -1,6 +1,8 @@
 package kappzzang.jeongsan.service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import kappzzang.jeongsan.domain.Item;
 import kappzzang.jeongsan.domain.Member;
 import kappzzang.jeongsan.domain.PersonalExpense;
@@ -27,20 +29,30 @@ public class PersonalExpenseService {
     private final ItemRepository itemRepository;
     private final PersonalExpenseRepository personalExpenseRepository;
 
+    private final Map<Long, Object> locks = new ConcurrentHashMap<>();
+
     @Transactional
-    public synchronized void savePersonalExpense(Long memberId, Long teamId, Long expenseId,
+    public void savePersonalExpense(Long memberId, Long teamId, Long expenseId,
         SavePersonalExpenseRequest personalExpense) {
 
-        Member member = getMemberIfTeamAndExpenseValid(memberId, teamId, expenseId);
+        locks.computeIfAbsent(expenseId, id -> new Object());
 
-        for (ItemInfo itemInfo : personalExpense.items()) {
-            Item item = getItemIfItemInfoValid(itemInfo, member);
-            List<PersonalExpense> personalExpenses = personalExpenseRepository.findAllByItem(item);
-            if (personalExpenses.isEmpty()) {
-                saveNewPersonalExpense(member, item, itemInfo.quantity(),
-                    item.getUnitPrice() * itemInfo.quantity());
-            } else {
-                updateAndSaveRecords(personalExpenses, item, itemInfo, member);
+        synchronized (locks.get(expenseId)) {
+            try {
+                Member member = getMemberIfTeamAndExpenseValid(memberId, teamId, expenseId);
+
+                for (ItemInfo itemInfo : personalExpense.items()) {
+                    Item item = getItemIfItemInfoValid(itemInfo, member);
+                    List<PersonalExpense> personalExpenses = personalExpenseRepository.findAllByItem(item);
+                    if (personalExpenses.isEmpty()) {
+                        saveNewPersonalExpense(member, item, itemInfo.quantity(),
+                            item.getUnitPrice() * itemInfo.quantity());
+                    } else {
+                        updateAndSaveRecords(personalExpenses, item, itemInfo, member);
+                    }
+                }
+            } finally {
+                locks.remove(expenseId);
             }
         }
     }

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -3,9 +3,11 @@ package kappzzang.jeongsan.service;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import kappzzang.jeongsan.domain.Expense;
 import kappzzang.jeongsan.domain.Item;
 import kappzzang.jeongsan.domain.Member;
 import kappzzang.jeongsan.domain.PersonalExpense;
+import kappzzang.jeongsan.domain.Team;
 import kappzzang.jeongsan.dto.request.SavePersonalExpenseRequest;
 import kappzzang.jeongsan.dto.request.SavePersonalExpenseRequest.ItemInfo;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
@@ -14,6 +16,7 @@ import kappzzang.jeongsan.repository.ExpenseRepository;
 import kappzzang.jeongsan.repository.ItemRepository;
 import kappzzang.jeongsan.repository.MemberRepository;
 import kappzzang.jeongsan.repository.PersonalExpenseRepository;
+import kappzzang.jeongsan.repository.TeamMemberRepository;
 import kappzzang.jeongsan.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,6 +31,7 @@ public class PersonalExpenseService {
     private final ExpenseRepository expenseRepository;
     private final ItemRepository itemRepository;
     private final PersonalExpenseRepository personalExpenseRepository;
+    private final TeamMemberRepository teamMemberRepository;
 
     private final Map<Long, Object> locks = new ConcurrentHashMap<>();
 
@@ -43,7 +47,8 @@ public class PersonalExpenseService {
 
                 for (ItemInfo itemInfo : personalExpense.items()) {
                     Item item = getItemIfItemInfoValid(itemInfo, member);
-                    List<PersonalExpense> personalExpenses = personalExpenseRepository.findAllByItem(item);
+                    List<PersonalExpense> personalExpenses = personalExpenseRepository.findAllByItem(
+                        item);
                     if (personalExpenses.isEmpty()) {
                         saveNewPersonalExpense(member, item, itemInfo.quantity(),
                             item.getUnitPrice() * itemInfo.quantity());
@@ -58,13 +63,19 @@ public class PersonalExpenseService {
     }
 
     private Member getMemberIfTeamAndExpenseValid(Long memberId, Long teamId, Long expenseId) {
-        teamRepository.findById(teamId)
+        Team team = teamRepository.findById(teamId)
             .orElseThrow(() -> new JeongsanException(ErrorType.TEAM_NOT_FOUND));
-        expenseRepository.findById(expenseId)
+        Expense expense = expenseRepository.findById(expenseId)
             .orElseThrow(() -> new JeongsanException(ErrorType.EXPENSE_NOT_FOUND));
-
-        return memberRepository.findById(memberId)
+        Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new JeongsanException(ErrorType.USER_NOT_FOUND));
+        teamMemberRepository.findTeamMemberByTeamAndMember(team, member)
+            .orElseThrow(() -> new JeongsanException(ErrorType.TEAM_MEMBER_NOT_FOUND));
+        if (!expense.getTeam().equals(team)) {
+            throw new JeongsanException(ErrorType.EXPENSE_NOT_IN_TEAM);
+        }
+
+        return member;
     }
 
     private Item getItemIfItemInfoValid(ItemInfo itemInfo, Member member) {

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -34,28 +34,15 @@ public class PersonalExpenseService {
         Member member = getMemberIfTeamAndExpenseValid(memberId, teamId, expenseId);
 
         for (ItemInfo itemInfo : personalExpense.items()) {
-            Item item = getItemIfItemInfoValid(itemInfo);
-
-            personalExpenseRepository.findByMemberAndItem(member, item).ifPresent(data -> {
-                throw new JeongsanException(ErrorType.ALREADY_CHECKED_ITEM);
-            });
-
+            Item item = getItemIfItemInfoValid(itemInfo, member);
             List<PersonalExpense> personalExpenses = personalExpenseRepository.findAllByItem(item);
             if (personalExpenses.isEmpty()) {
-                saveFirstRecord(member, item, itemInfo.quantity());
+                saveNewPersonalExpense(member, item, itemInfo.quantity(),
+                    item.getUnitPrice() * itemInfo.quantity());
             } else {
                 updateAndSaveRecords(personalExpenses, item, itemInfo, member);
             }
         }
-    }
-
-    private Item getItemIfItemInfoValid(ItemInfo itemInfo) {
-        Item item = itemRepository.findById(itemInfo.itemId())
-            .orElseThrow(() -> new JeongsanException(ErrorType.ITEM_NOT_FOUND));
-        if (item.getQuantity() < itemInfo.quantity()) {
-            throw new JeongsanException(ErrorType.INVALID_QUANTITY);
-        }
-        return item;
     }
 
     private Member getMemberIfTeamAndExpenseValid(Long memberId, Long teamId, Long expenseId) {
@@ -68,6 +55,18 @@ public class PersonalExpenseService {
             .orElseThrow(() -> new JeongsanException(ErrorType.USER_NOT_FOUND));
     }
 
+    private Item getItemIfItemInfoValid(ItemInfo itemInfo, Member member) {
+        Item item = itemRepository.findById(itemInfo.itemId())
+            .orElseThrow(() -> new JeongsanException(ErrorType.ITEM_NOT_FOUND));
+        personalExpenseRepository.findByMemberAndItem(member, item).ifPresent(data -> {
+            throw new JeongsanException(ErrorType.ALREADY_CHECKED_ITEM);
+        });
+        if (item.getQuantity() < itemInfo.quantity()) {
+            throw new JeongsanException(ErrorType.INVALID_QUANTITY);
+        }
+        return item;
+    }
+
     private void updateAndSaveRecords(List<PersonalExpense> personalExpenses, Item item,
         ItemInfo itemInfo, Member member) {
 
@@ -75,23 +74,26 @@ public class PersonalExpenseService {
             .sum() + itemInfo.quantity();
         int requestedMemberPrice = calculateRequestMemberPrice(item.getTotalPrice(),
             totalQuantity, itemInfo.quantity());
-        int newTotalPrice = item.getTotalPrice() / totalQuantity;
+        int newPersonalUnitPrice = item.getTotalPrice() / totalQuantity;
+
+        updateExistingPersonalExpenses(personalExpenses, newPersonalUnitPrice);
+        saveNewPersonalExpense(member, item, itemInfo.quantity(), requestedMemberPrice);
+    }
+
+    private void updateExistingPersonalExpenses(List<PersonalExpense> personalExpenses,
+        int newPersonalUnitPrice) {
 
         personalExpenses.forEach(personalExpense -> {
             PersonalExpense updatedPersonalExpense = personalExpense.toBuilder()
-                .totalPrice(newTotalPrice * personalExpense.getQuantity()).build();
+                .totalPrice(newPersonalUnitPrice * personalExpense.getQuantity()).build();
             savePersonalExpense(updatedPersonalExpense);
         });
-
-        PersonalExpense newPersonalExpense = PersonalExpense.builder().member(member).item(item)
-            .quantity(itemInfo.quantity()).totalPrice(requestedMemberPrice).build();
-        savePersonalExpense(newPersonalExpense);
     }
 
-    private void saveFirstRecord(Member member, Item item, Integer quantity) {
-        PersonalExpense personalExpense = PersonalExpense.builder().member(member).item(item)
-            .quantity(quantity).totalPrice(item.getUnitPrice() * quantity).build();
-        personalExpenseRepository.save(personalExpense);
+    private void saveNewPersonalExpense(Member member, Item item, int quantity, int totalPrice) {
+        PersonalExpense newPersonalExpense = PersonalExpense.builder().member(member).item(item)
+            .quantity(quantity).totalPrice(totalPrice).build();
+        savePersonalExpense(newPersonalExpense);
     }
 
     private int calculateRequestMemberPrice(int totalPrice, int totalQuantity,

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -1,6 +1,5 @@
 package kappzzang.jeongsan.service;
 
-import jakarta.transaction.Transactional;
 import java.util.List;
 import kappzzang.jeongsan.domain.Item;
 import kappzzang.jeongsan.domain.Member;
@@ -16,6 +15,7 @@ import kappzzang.jeongsan.repository.PersonalExpenseRepository;
 import kappzzang.jeongsan.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,7 +28,7 @@ public class PersonalExpenseService {
     private final PersonalExpenseRepository personalExpenseRepository;
 
     @Transactional
-    public void savePersonalExpense(Long memberId, Long teamId, Long expenseId,
+    public synchronized void savePersonalExpense(Long memberId, Long teamId, Long expenseId,
         SavePersonalExpenseRequest personalExpense) {
 
         Member member = getMemberIfTeamAndExpenseValid(memberId, teamId, expenseId);
@@ -84,16 +84,14 @@ public class PersonalExpenseService {
         int newPersonalUnitPrice) {
 
         personalExpenses.forEach(personalExpense -> {
-            PersonalExpense updatedPersonalExpense = personalExpense.toBuilder()
-                .totalPrice(newPersonalUnitPrice * personalExpense.getQuantity()).build();
-            savePersonalExpense(updatedPersonalExpense);
+            personalExpense.updateTotalPrice(newPersonalUnitPrice * personalExpense.getQuantity());
         });
     }
 
     private void saveNewPersonalExpense(Member member, Item item, int quantity, int totalPrice) {
         PersonalExpense newPersonalExpense = PersonalExpense.builder().member(member).item(item)
             .quantity(quantity).totalPrice(totalPrice).build();
-        savePersonalExpense(newPersonalExpense);
+        personalExpenseRepository.save(newPersonalExpense);
     }
 
     private int calculateRequestMemberPrice(int totalPrice, int totalQuantity,
@@ -101,9 +99,5 @@ public class PersonalExpenseService {
         int newTotalPrice = (totalPrice / totalQuantity) * requestQuantity;
         int remainder = totalPrice % totalQuantity;
         return newTotalPrice + remainder;
-    }
-
-    private void savePersonalExpense(PersonalExpense personalExpense) {
-        personalExpenseRepository.save(personalExpense);
     }
 }

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -61,10 +61,14 @@ public class PersonalExpenseService {
         personalExpenseRepository.findByMemberAndItem(member, item).ifPresent(data -> {
             throw new JeongsanException(ErrorType.ALREADY_CHECKED_ITEM);
         });
+        checkRequestQuantityValidity(itemInfo, item);
+        return item;
+    }
+
+    private void checkRequestQuantityValidity(ItemInfo itemInfo, Item item) {
         if (item.getQuantity() < itemInfo.quantity()) {
             throw new JeongsanException(ErrorType.INVALID_QUANTITY);
         }
-        return item;
     }
 
     private void updateAndSaveRecords(List<PersonalExpense> personalExpenses, Item item,

--- a/src/test/java/kappzzang/jeongsan/repository/ExpenseRepositoryTest.java
+++ b/src/test/java/kappzzang/jeongsan/repository/ExpenseRepositoryTest.java
@@ -53,14 +53,14 @@ public class ExpenseRepositoryTest {
         Item itemD = testDataUtil.createAndPersistItem("TEST_ITEM_D", 3, 1000);
 
         PersonalExpense personalExpenseA = testDataUtil.createAndPersistPersonalExpense(memberA, 5,
-            itemA,0);
+            itemA, 0);
 
         PersonalExpense personalExpenseB = testDataUtil.createAndPersistPersonalExpense(memberB, 3,
-            itemB,0);
+            itemB, 0);
         PersonalExpense personalExpenseC = testDataUtil.createAndPersistPersonalExpense(memberB, 9,
-            itemC,0);
+            itemC, 0);
         PersonalExpense personalExpenseD = testDataUtil.createAndPersistPersonalExpense(memberB,
-            10, itemD,0);
+            10, itemD, 0);
 
         List<Item> items = List.of(itemA, itemB, itemC, itemD);
         Category category = testDataUtil.createAndPersistCategory();

--- a/src/test/java/kappzzang/jeongsan/repository/ExpenseRepositoryTest.java
+++ b/src/test/java/kappzzang/jeongsan/repository/ExpenseRepositoryTest.java
@@ -53,14 +53,14 @@ public class ExpenseRepositoryTest {
         Item itemD = testDataUtil.createAndPersistItem("TEST_ITEM_D", 3, 1000);
 
         PersonalExpense personalExpenseA = testDataUtil.createAndPersistPersonalExpense(memberA, 5,
-            itemA);
+            itemA,0);
 
         PersonalExpense personalExpenseB = testDataUtil.createAndPersistPersonalExpense(memberB, 3,
-            itemB);
+            itemB,0);
         PersonalExpense personalExpenseC = testDataUtil.createAndPersistPersonalExpense(memberB, 9,
-            itemC);
+            itemC,0);
         PersonalExpense personalExpenseD = testDataUtil.createAndPersistPersonalExpense(memberB,
-            10, itemD);
+            10, itemD,0);
 
         List<Item> items = List.of(itemA, itemB, itemC, itemD);
         Category category = testDataUtil.createAndPersistCategory();

--- a/src/test/java/kappzzang/jeongsan/repository/TestDataUtil.java
+++ b/src/test/java/kappzzang/jeongsan/repository/TestDataUtil.java
@@ -76,11 +76,12 @@ public class TestDataUtil {
 
     //PersonalExpense
     public PersonalExpense createAndPersistPersonalExpense(Member member,
-        Integer consumedQuantity, Item item) {
+        Integer consumedQuantity, Item item,int totalPrice) {
         PersonalExpense personalExpense = PersonalExpense.builder()
             .member(member)
             .quantity(consumedQuantity)
             .item(item)
+            .totalPrice(totalPrice)
             .build();
         entityManager.persist(personalExpense);
         return personalExpense;

--- a/src/test/java/kappzzang/jeongsan/repository/TestDataUtil.java
+++ b/src/test/java/kappzzang/jeongsan/repository/TestDataUtil.java
@@ -76,7 +76,7 @@ public class TestDataUtil {
 
     //PersonalExpense
     public PersonalExpense createAndPersistPersonalExpense(Member member,
-        Integer consumedQuantity, Item item,int totalPrice) {
+        Integer consumedQuantity, Item item, int totalPrice) {
         PersonalExpense personalExpense = PersonalExpense.builder()
             .member(member)
             .quantity(consumedQuantity)

--- a/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
@@ -1,0 +1,135 @@
+package kappzzang.jeongsan.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import kappzzang.jeongsan.domain.Expense;
+import kappzzang.jeongsan.domain.Item;
+import kappzzang.jeongsan.domain.Member;
+import kappzzang.jeongsan.domain.PersonalExpense;
+import kappzzang.jeongsan.domain.Team;
+import kappzzang.jeongsan.dto.request.SavePersonalExpenseRequest;
+import kappzzang.jeongsan.repository.ExpenseRepository;
+import kappzzang.jeongsan.repository.ItemRepository;
+import kappzzang.jeongsan.repository.MemberRepository;
+import kappzzang.jeongsan.repository.PersonalExpenseRepository;
+import kappzzang.jeongsan.repository.TeamRepository;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PersonalExpenseServiceTest {
+
+    @Autowired
+    private PersonalExpenseService personalExpenseService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TeamRepository teamRepository;
+    @Autowired
+    private ExpenseRepository expenseRepository;
+    @Autowired
+    private ItemRepository itemRepository;
+    @Autowired
+    private PersonalExpenseRepository personalExpenseRepository;
+
+    private Member member1, member2, member3;
+    private Team team;
+    private Expense expense;
+    private Item item;
+
+    @BeforeAll
+    void setup() {
+        team = teamRepository.save(new Team("Test Team", "🍎"));
+        member1 = memberRepository.save(
+            new Member("kakaoId1", "email1@test.com", "User1", null, null, null));
+        member2 = memberRepository.save(
+            new Member("kakaoId2", "email2@test.com", "User2", null, null, null));
+        member3 = memberRepository.save(
+            new Member("kakaoId3", "email3@test.com", "User3", null, null, null));
+        item = new Item("Test Item", 2, 1000);
+        expense = Expense.builder()
+            .title("asdf")
+            .category(null)
+            .imageUrl("image.jpg")
+            .team(team)
+            .member(member1)
+            .items(List.of(item))
+            .paymentTime(LocalDateTime.now())
+            .build();
+        expense = expenseRepository.save(expense);
+        itemRepository.save(item);
+    }
+
+    @Test
+    @DisplayName("개인 소비 내역 저장 - 동시성 테스트")
+    void personalExpenseSaveConcurrencyTest() throws InterruptedException {
+        int threadCount = 3;
+        List<Member> members = List.of(member1, member2, member3);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(threadCount);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            Member testMember = members.get(i);
+
+            executorService.submit(() -> {
+                try {
+                    startLatch.await(); // 모든 스레드 대기
+                    SavePersonalExpenseRequest request = new SavePersonalExpenseRequest(
+                        List.of(new SavePersonalExpenseRequest.ItemInfo(item.getId(), 1)));
+                    personalExpenseService.savePersonalExpense(testMember.getId(), team.getId(),
+                        expense.getId(), request);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        endLatch.await();
+        executorService.shutdown();
+
+        List<PersonalExpense> savedExpenses = personalExpenseRepository.findAllByItem(item);
+        savedExpenses.forEach(
+            o -> System.out.println(o.getId()));
+
+        assertEquals(3, savedExpenses.size());
+
+        assertTrue(
+            savedExpenses.stream().anyMatch(pe -> pe.getMember().getId().equals(member1.getId())));
+        assertTrue(
+            savedExpenses.stream().anyMatch(pe -> pe.getMember().getId().equals(member2.getId())));
+        assertTrue(
+            savedExpenses.stream().anyMatch(pe -> pe.getMember().getId().equals(member3.getId())));
+
+        //예상 출력값 = 666, 666, 668
+        savedExpenses.forEach(
+            o -> System.out.println(
+                "expenseId" + o.getId() + "-member" + o.getMember().getId() + ": "
+                    + o.getTotalPrice()));
+    }
+
+    @AfterAll
+    void cleanup() {
+        personalExpenseRepository.deleteAll();
+        itemRepository.deleteAll();
+        expenseRepository.deleteAll();
+        teamRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+}

--- a/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 import kappzzang.jeongsan.domain.Expense;
 import kappzzang.jeongsan.domain.Item;
 import kappzzang.jeongsan.domain.Member;
@@ -94,9 +95,13 @@ class PersonalExpenseServiceTest {
         // given
         int threadCount = 3;
         List<Member> members = List.of(member1, member2, member3);
+        List<Integer> expectedTotalPrices = List.of(666, 666, 668);
         CountDownLatch startLatch = new CountDownLatch(1);
         CountDownLatch endLatch = new CountDownLatch(threadCount);
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+
+        // 마지막에 완료된 memberId 저장 목적
+        AtomicReference<Long> lastCompletedMemberId = new AtomicReference<>();
 
         // when
         for (int i = 0; i < threadCount; i++) {
@@ -109,6 +114,8 @@ class PersonalExpenseServiceTest {
                         List.of(new SavePersonalExpenseRequest.ItemInfo(item1.getId(), 1)));
                     personalExpenseService.savePersonalExpense(testMember.getId(), team.getId(),
                         expense.getId(), request);
+
+                    lastCompletedMemberId.set(testMember.getId());  // 마지막에 완료된 memberId 저장
                 } catch (Exception e) {
                     e.printStackTrace();
                 } finally {
@@ -123,8 +130,15 @@ class PersonalExpenseServiceTest {
 
         // then
         List<PersonalExpense> savedExpenses = personalExpenseRepository.findAllByItem(item1);
-        assertEquals(3, savedExpenses.size());
+        List<Integer> actualTotalPrices = savedExpenses.stream().map(PersonalExpense::getTotalPrice)
+            .sorted().toList();
 
+        Long lastUpdatedMemberId = lastCompletedMemberId.get();
+        Integer lastMemberTotalPrice = savedExpenses.stream()
+            .filter(expense -> expense.getMember().getId().equals(lastUpdatedMemberId))
+            .map(PersonalExpense::getTotalPrice).findFirst().orElse(0);
+
+        assertEquals(3, savedExpenses.size());
         assertTrue(
             savedExpenses.stream().anyMatch(pe -> pe.getMember().getId().equals(member1.getId())));
         assertTrue(
@@ -132,11 +146,8 @@ class PersonalExpenseServiceTest {
         assertTrue(
             savedExpenses.stream().anyMatch(pe -> pe.getMember().getId().equals(member3.getId())));
 
-        //예상 출력값 = 666, 666, 668
-        savedExpenses.forEach(
-            o -> System.out.println(
-                "expenseId" + o.getId() + "-member" + o.getMember().getId() + ": "
-                    + o.getTotalPrice()));
+        assertEquals(expectedTotalPrices, actualTotalPrices);   // 전체 값 검증
+        assertEquals(expectedTotalPrices.get(2), lastMemberTotalPrice); // 마지막에 완료 된 값 668 검증
     }
 
     @Test

--- a/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -152,8 +153,10 @@ class PersonalExpenseServiceTest {
         List<PersonalExpense> savedExpenses = personalExpenseRepository.findAllByItem(item2);
         assertEquals(2, savedExpenses.size());
 
-        //예상 출력값 = 500, 500
-        savedExpenses.forEach(expense -> System.out.println(
-            "member" + expense.getMember().getId() + " totalPrice: " + expense.getTotalPrice()));
+        PersonalExpense personalExpense1 = savedExpenses.get(0);
+        PersonalExpense personalExpense2 = savedExpenses.get(1);
+
+        assertEquals(personalExpense1.getQuantity(), personalExpense2.getQuantity());
+        assertEquals(personalExpense1.getTotalPrice(), personalExpense2.getTotalPrice());
     }
 }

--- a/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
@@ -1,6 +1,7 @@
 package kappzzang.jeongsan.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
@@ -14,6 +15,8 @@ import kappzzang.jeongsan.domain.Member;
 import kappzzang.jeongsan.domain.PersonalExpense;
 import kappzzang.jeongsan.domain.Team;
 import kappzzang.jeongsan.dto.request.SavePersonalExpenseRequest;
+import kappzzang.jeongsan.dto.request.SavePersonalExpenseRequest.ItemInfo;
+import kappzzang.jeongsan.global.exception.JeongsanException;
 import kappzzang.jeongsan.repository.ExpenseRepository;
 import kappzzang.jeongsan.repository.ItemRepository;
 import kappzzang.jeongsan.repository.MemberRepository;
@@ -157,5 +160,24 @@ class PersonalExpenseServiceTest {
 
         assertEquals(personalExpense1.getQuantity(), personalExpense2.getQuantity());
         assertEquals(personalExpense1.getTotalPrice(), personalExpense2.getTotalPrice());
+    }
+
+    @Test
+    @DisplayName("개인 소비 내역 저장 - 예외 발생 테스트")
+    void savePersonalExpenseExceptionTest() {
+
+        // given
+        SavePersonalExpenseRequest request = new SavePersonalExpenseRequest(
+            List.of(new ItemInfo(item2.getId(), 10))
+        );
+
+        // when, then
+        assertThrows(JeongsanException.class, () -> {
+            personalExpenseService.savePersonalExpense(member1.getId(), team.getId(),
+                expense.getId(), request);
+        });
+
+        List<PersonalExpense> savedExpenses = personalExpenseRepository.findAll();
+        assertEquals(1, savedExpenses.size());
     }
 }

--- a/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
@@ -15,6 +15,7 @@ import kappzzang.jeongsan.domain.Item;
 import kappzzang.jeongsan.domain.Member;
 import kappzzang.jeongsan.domain.PersonalExpense;
 import kappzzang.jeongsan.domain.Team;
+import kappzzang.jeongsan.domain.TeamMember;
 import kappzzang.jeongsan.dto.request.SavePersonalExpenseRequest;
 import kappzzang.jeongsan.dto.request.SavePersonalExpenseRequest.ItemInfo;
 import kappzzang.jeongsan.global.exception.JeongsanException;
@@ -22,6 +23,7 @@ import kappzzang.jeongsan.repository.ExpenseRepository;
 import kappzzang.jeongsan.repository.ItemRepository;
 import kappzzang.jeongsan.repository.MemberRepository;
 import kappzzang.jeongsan.repository.PersonalExpenseRepository;
+import kappzzang.jeongsan.repository.TeamMemberRepository;
 import kappzzang.jeongsan.repository.TeamRepository;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -47,6 +49,8 @@ class PersonalExpenseServiceTest {
     private ItemRepository itemRepository;
     @Autowired
     private PersonalExpenseRepository personalExpenseRepository;
+    @Autowired
+    private TeamMemberRepository teamMemberRepository;
 
     private Member member1, member2, member3;
     private Team team;
@@ -77,6 +81,9 @@ class PersonalExpenseServiceTest {
         itemRepository.save(item1);
         itemRepository.save(item2);
         personalExpenseRepository.save(new PersonalExpense(member1, item2, 1, 1000));
+        teamMemberRepository.save(new TeamMember(member1, team, false, true));
+        teamMemberRepository.save(new TeamMember(member2, team, false, true));
+        teamMemberRepository.save(new TeamMember(member3, team, false, true));
     }
 
     @AfterAll
@@ -86,6 +93,7 @@ class PersonalExpenseServiceTest {
         expenseRepository.deleteAll();
         teamRepository.deleteAll();
         memberRepository.deleteAll();
+        teamMemberRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
@@ -47,7 +47,7 @@ class PersonalExpenseServiceTest {
     private Member member1, member2, member3;
     private Team team;
     private Expense expense;
-    private Item item;
+    private Item item1, item2;
 
     @BeforeAll
     void setup() {
@@ -58,30 +58,44 @@ class PersonalExpenseServiceTest {
             new Member("kakaoId2", "email2@test.com", "User2", null, null, null));
         member3 = memberRepository.save(
             new Member("kakaoId3", "email3@test.com", "User3", null, null, null));
-        item = new Item("Test Item", 2, 1000);
+        item1 = new Item("Test Item", 2, 1000);
+        item2 = new Item("Test Item", 1, 1000);
         expense = Expense.builder()
             .title("asdf")
             .category(null)
             .imageUrl("image.jpg")
             .team(team)
             .member(member1)
-            .items(List.of(item))
+            .items(List.of(item1))
             .paymentTime(LocalDateTime.now())
             .build();
         expense = expenseRepository.save(expense);
-        itemRepository.save(item);
+        itemRepository.save(item1);
+        itemRepository.save(item2);
+        personalExpenseRepository.save(new PersonalExpense(member1, item2, 1, 1000));
+    }
+
+    @AfterAll
+    void cleanup() {
+        personalExpenseRepository.deleteAll();
+        itemRepository.deleteAll();
+        expenseRepository.deleteAll();
+        teamRepository.deleteAll();
+        memberRepository.deleteAll();
     }
 
     @Test
     @DisplayName("개인 소비 내역 저장 - 동시성 테스트")
     void personalExpenseSaveConcurrencyTest() throws InterruptedException {
+
+        // given
         int threadCount = 3;
         List<Member> members = List.of(member1, member2, member3);
         CountDownLatch startLatch = new CountDownLatch(1);
         CountDownLatch endLatch = new CountDownLatch(threadCount);
-
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
 
+        // when
         for (int i = 0; i < threadCount; i++) {
             Member testMember = members.get(i);
 
@@ -89,7 +103,7 @@ class PersonalExpenseServiceTest {
                 try {
                     startLatch.await(); // 모든 스레드 대기
                     SavePersonalExpenseRequest request = new SavePersonalExpenseRequest(
-                        List.of(new SavePersonalExpenseRequest.ItemInfo(item.getId(), 1)));
+                        List.of(new SavePersonalExpenseRequest.ItemInfo(item1.getId(), 1)));
                     personalExpenseService.savePersonalExpense(testMember.getId(), team.getId(),
                         expense.getId(), request);
                 } catch (Exception e) {
@@ -104,10 +118,8 @@ class PersonalExpenseServiceTest {
         endLatch.await();
         executorService.shutdown();
 
-        List<PersonalExpense> savedExpenses = personalExpenseRepository.findAllByItem(item);
-        savedExpenses.forEach(
-            o -> System.out.println(o.getId()));
-
+        // then
+        List<PersonalExpense> savedExpenses = personalExpenseRepository.findAllByItem(item1);
         assertEquals(3, savedExpenses.size());
 
         assertTrue(
@@ -124,12 +136,24 @@ class PersonalExpenseServiceTest {
                     + o.getTotalPrice()));
     }
 
-    @AfterAll
-    void cleanup() {
-        personalExpenseRepository.deleteAll();
-        itemRepository.deleteAll();
-        expenseRepository.deleteAll();
-        teamRepository.deleteAll();
-        memberRepository.deleteAll();
+    @Test
+    @DisplayName("개인 소비 내역 저장 - 기존 데이터 업데이트 테스트")
+    void updatePersonalExpenseTest() {
+
+        // given
+        SavePersonalExpenseRequest request = new SavePersonalExpenseRequest(
+            List.of(new SavePersonalExpenseRequest.ItemInfo(item2.getId(), 1)));
+
+        // when
+        personalExpenseService.savePersonalExpense(member2.getId(), team.getId(), expense.getId(),
+            request);
+
+        // then
+        List<PersonalExpense> savedExpenses = personalExpenseRepository.findAllByItem(item2);
+        assertEquals(2, savedExpenses.size());
+
+        //예상 출력값 = 500, 500
+        savedExpenses.forEach(expense -> System.out.println(
+            "member" + expense.getMember().getId() + " totalPrice: " + expense.getTotalPrice()));
     }
 }


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 개인 소비 내역 저장 api 구현
- 정상 작동, 동시성, 예외 발생 테스트


### 🔍 참고 사항
- 지난번에 올린 PR 코멘트 반영된 버전입니다.
- 동시성 문제에 대하여 `Lock`을 걸어도 해결되지 않아서 `synchronized`를 사용해서 한 스레드만 해당 메서드에 접근할 수 있도록 했습니다.
- 지난 PR에 올려주신 테스트 코드 약간 수정해서 반영했습니다.

### ⚠️ 의논 필요
- 팀원들의 의견을 듣고 싶거나, 의논이 필요한 사항이 있다면 작성

### 🐞현재 버그
- 현재 버전에 버그가 있다면 작성

### #️⃣ 연관 이슈(Git Close)
- close #86 
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
