### PR TITLE
Feature/issue#100: 카카오 페이 송금 링크 조회 API 구현

### DIFF
--- a/src/main/java/kappzzang/jeongsan/controller/MemberController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/MemberController.java
@@ -7,6 +7,7 @@ import kappzzang.jeongsan.controller.docs.MemberControllerInterface;
 import kappzzang.jeongsan.dto.request.JoinTeamRequest;
 import kappzzang.jeongsan.dto.request.LoginRequest;
 import kappzzang.jeongsan.dto.request.RefreshRequest;
+import kappzzang.jeongsan.dto.response.GetPayLinkResponse;
 import kappzzang.jeongsan.dto.response.LoginResponse;
 import kappzzang.jeongsan.dto.response.RefreshResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
@@ -15,6 +16,7 @@ import kappzzang.jeongsan.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -48,8 +50,15 @@ public class MemberController implements MemberControllerInterface {
     @PostMapping("/join/{teamId}")
     public ResponseEntity<JeongsanApiResponse<Void>> joinTeam(@PathVariable("teamId") Long teamId,
         @RequestBody JoinTeamRequest request) {
-
         memberService.acceptInvite(teamId, request.memberId());
         return JeongsanApiResponse.success(JOIN_SUCCESS);
+    }
+
+    @Override
+    @GetMapping("/link")
+    public ResponseEntity<JeongsanApiResponse<GetPayLinkResponse>> getPayLink(
+        @AuthenticationPrincipal Long memberId) {
+        GetPayLinkResponse data = memberService.getPayLink(memberId);
+        return JeongsanApiResponse.success(SuccessType.PAY_LINK_LOADED, data);
     }
 }

--- a/src/main/java/kappzzang/jeongsan/controller/docs/MemberControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/MemberControllerInterface.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import kappzzang.jeongsan.dto.request.JoinTeamRequest;
 import kappzzang.jeongsan.dto.request.LoginRequest;
 import kappzzang.jeongsan.dto.request.RefreshRequest;
+import kappzzang.jeongsan.dto.response.GetPayLinkResponse;
 import kappzzang.jeongsan.dto.response.LoginResponse;
 import kappzzang.jeongsan.dto.response.RefreshResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
@@ -44,4 +45,9 @@ public interface MemberControllerInterface {
         @ApiResponse(responseCode = "404", description = "잘못된 memberId, 사용자를 찾을 수 없음. (ErrorCode-E404001)"),
         @ApiResponse(responseCode = "404", description = "잘못된 teamId, 모임을 찾을 수 없음. (ErrorCode-E404002)")})
     ResponseEntity<JeongsanApiResponse<Void>> joinTeam(Long teamId, JoinTeamRequest request);
+
+    @Operation(summary = "송금 링크 조회 API", description = "카카오페이 송금 링크를 조회하는 API")
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "카카오 페이 송금 링크 조회 성공"),
+        @ApiResponse(responseCode = "404", description = "카카오 페이 송금 링크를 찾을 수 없음. (ErrorCode-E404)")})
+    ResponseEntity<JeongsanApiResponse<GetPayLinkResponse>> getPayLink(Long memberId);
 }

--- a/src/main/java/kappzzang/jeongsan/domain/KakaoPayInfo.java
+++ b/src/main/java/kappzzang/jeongsan/domain/KakaoPayInfo.java
@@ -12,4 +12,8 @@ public class KakaoPayInfo {
     private String payUrl;
     private String payAccessToken;
     private String payRefreshToken;
+
+    public KakaoPayInfo(String payUrl) {
+        this.payUrl = payUrl;
+    }
 }

--- a/src/main/java/kappzzang/jeongsan/domain/Member.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Member.java
@@ -50,4 +50,9 @@ public class Member extends BaseEntity {
         this.refreshToken = refreshToken;
         this.kakaoPayInfo = kakaoPayInfo;
     }
+
+    public Member(String nickname, KakaoPayInfo kakaoPayInfo) {
+        this.nickname = nickname;
+        this.kakaoPayInfo = kakaoPayInfo;
+    }
 }

--- a/src/main/java/kappzzang/jeongsan/dto/response/GetPayLinkResponse.java
+++ b/src/main/java/kappzzang/jeongsan/dto/response/GetPayLinkResponse.java
@@ -1,0 +1,5 @@
+package kappzzang.jeongsan.dto.response;
+
+public record GetPayLinkResponse(String kakaoPayLink) {
+
+}

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
@@ -34,6 +34,7 @@ public enum ErrorType {
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "E404003", "카테고리을 찾을 수 없습니다."),
     EXPENSE_NOT_FOUND(HttpStatus.NOT_FOUND, "E404004", "지출을 찾을 수 없습니다."),
     INVITATION_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "E404006", "초대 현황을 찾을 수 없습니다."),
+    KAKAO_PAY_LINK_NOT_FOUND(HttpStatus.NOT_FOUND, "E404", "카카오 페이 송금 링크를 찾을 수 없습니다."),
 
     //408 REQUEST_TIMEOUT
     EXTERNAL_API_REQUEST_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "E408001", "외부 API 요청 시간이 초과되었습니다."),

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
@@ -14,6 +14,7 @@ public enum SuccessType {
     PERSONAL_EXPENSE_LOADED(HttpStatus.OK, "개인 지출 목록을 불러오는 데 성공했습니다."),
     INVITATION_STATUS_LOADED(HttpStatus.OK, "모임의 멤버 초대 현황을 불러오는 데 성공했습니다."),
     ACCESS_TOKEN_REISSUED(HttpStatus.OK, "액세스 토큰이 재발급되었습니다."),
+    PAY_LINK_LOADED(HttpStatus.OK, "카카오 페이 송금 링크 조회 성공"),
 
     // 201 CREATED
     TEAM_CREATED(HttpStatus.CREATED, "모임이 생성되었습니다."),

--- a/src/main/java/kappzzang/jeongsan/service/MemberService.java
+++ b/src/main/java/kappzzang/jeongsan/service/MemberService.java
@@ -1,5 +1,6 @@
 package kappzzang.jeongsan.service;
 
+import static kappzzang.jeongsan.global.common.enumeration.ErrorType.KAKAO_PAY_LINK_NOT_FOUND;
 import static kappzzang.jeongsan.global.common.enumeration.ErrorType.NOT_INVITED_MEMBER;
 import static kappzzang.jeongsan.global.common.enumeration.ErrorType.REFRESH_TOKEN_INVALID;
 import static kappzzang.jeongsan.global.common.enumeration.ErrorType.TEAM_NOT_FOUND;
@@ -10,6 +11,7 @@ import kappzzang.jeongsan.domain.Team;
 import kappzzang.jeongsan.domain.TeamMember;
 import kappzzang.jeongsan.dto.request.LoginRequest;
 import kappzzang.jeongsan.dto.request.RefreshRequest;
+import kappzzang.jeongsan.dto.response.GetPayLinkResponse;
 import kappzzang.jeongsan.dto.response.LoginResponse;
 import kappzzang.jeongsan.dto.response.RefreshResponse;
 import kappzzang.jeongsan.global.client.dto.response.KakaoProfileResponse;
@@ -67,7 +69,6 @@ public class MemberService {
 
     @Transactional
     public void acceptInvite(Long teamId, Long memberId) {
-
         Team team = teamRepository.findById(teamId)
             .orElseThrow(() -> new JeongsanException(TEAM_NOT_FOUND));
         Member member = memberRepository.findById(memberId)
@@ -76,5 +77,17 @@ public class MemberService {
             .orElseThrow(() -> new JeongsanException(NOT_INVITED_MEMBER));
 
         teamMember.acceptInvite();
+    }
+
+    @Transactional(readOnly = true)
+    public GetPayLinkResponse getPayLink(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new JeongsanException(USER_NOT_FOUND));
+        String payLink = member.getKakaoPayInfo().getPayUrl();
+        if (payLink == null) {
+            throw new JeongsanException(KAKAO_PAY_LINK_NOT_FOUND);
+        }
+
+        return new GetPayLinkResponse(payLink);
     }
 }

--- a/src/test/java/kappzzang/jeongsan/service/MemberServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/MemberServiceTest.java
@@ -2,6 +2,7 @@ package kappzzang.jeongsan.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -10,9 +11,11 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
 import java.util.Optional;
+import kappzzang.jeongsan.domain.KakaoPayInfo;
 import kappzzang.jeongsan.domain.Member;
 import kappzzang.jeongsan.dto.request.LoginRequest;
 import kappzzang.jeongsan.dto.request.RefreshRequest;
+import kappzzang.jeongsan.dto.response.GetPayLinkResponse;
 import kappzzang.jeongsan.dto.response.LoginResponse;
 import kappzzang.jeongsan.dto.response.RefreshResponse;
 import kappzzang.jeongsan.global.client.dto.response.KakaoProfileResponse;
@@ -113,6 +116,33 @@ public class MemberServiceTest {
         // then
         assertThat(refreshResponse.tokenType()).isEqualTo(BEARER);
         assertThat(refreshResponse.accessToken()).isEqualTo(TEST_ACCESS_TOKEN);
+    }
+
+    @Test
+    @DisplayName("카카오 페이 송금 링크 조회 테스트")
+    void getPayLink() {
+        // given
+        KakaoPayInfo kakaoPayInfo = new KakaoPayInfo("payLink");
+        given(memberRepository.findById(anyLong())).willReturn(
+            Optional.of(new Member("member", kakaoPayInfo)));
+
+        // when
+        GetPayLinkResponse getPayLinkResponse = memberService.getPayLink(1L);
+
+        // then
+        assertThat(getPayLinkResponse.kakaoPayLink()).isEqualTo("payLink");
+    }
+
+    @Test
+    @DisplayName("카카오 페이 송금 링크 조회 테스트 - 페이 링크가 null인 경우")
+    void getPayLinkException() {
+        // given
+        KakaoPayInfo kakaoPayInfo = new KakaoPayInfo(null);
+        given(memberRepository.findById(anyLong())).willReturn(
+            Optional.of(new Member("member", kakaoPayInfo)));
+
+        // when, then
+        assertThrows(JeongsanException.class, () -> memberService.getPayLink(1L));
     }
 
     private KakaoProfileResponse createKakaoProfileResponse() {


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 저장된 카카오 페이 송금 링크 조회 API 구현


### 🔍 참고 사항
- memberId는 필터에서 처리가 되므로 api 명세에 NOT_FOUND 관련 내용을 작성하지 않았습니다.

### ⚠️ 의논 필요
- 팀원들의 의견을 듣고 싶거나, 의논이 필요한 사항이 있다면 작성

### 🐞현재 버그
- 현재 버전에 버그가 있다면 작성

### #️⃣ 연관 이슈(Git Close)
- close #100 
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
