### PR TITLE
Feature/issue#97: 내가 지불한 지출 중 `송금 대기`상태인 지출 내역 조회 api 구현

### DIFF
--- a/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
@@ -60,6 +60,7 @@ public class ExpenseController implements ExpenseControllerInterface {
         return JeongsanApiResponse.success(SuccessType.EXPENSE_STATUS_CHANGE_SUCCESS);
     }
 
+    @Override
     @GetMapping("ipaid/{teamId}")
     public ResponseEntity<JeongsanApiResponse<ExpenseResponse>> getExpensesIPaid(
         @AuthenticationPrincipal Long memberId,

--- a/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/ExpenseController.java
@@ -59,4 +59,13 @@ public class ExpenseController implements ExpenseControllerInterface {
         expenseService.completeExpenses(request, teamId, memberId);
         return JeongsanApiResponse.success(SuccessType.EXPENSE_STATUS_CHANGE_SUCCESS);
     }
+
+    @GetMapping("ipaid/{teamId}")
+    public ResponseEntity<JeongsanApiResponse<ExpenseResponse>> getExpensesIPaid(
+        @AuthenticationPrincipal Long memberId,
+        @PathVariable Long teamId
+    ) {
+        return JeongsanApiResponse.success(SuccessType.EXPENSE_LIST_LOADED,
+            expenseService.getExpensesIPaid(memberId, teamId));
+    }
 }

--- a/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
@@ -45,7 +45,12 @@ public interface ExpenseControllerInterface {
                 + "요청 목록에 타 모임의 지출이 포함(ErrorCode=E400), "
                 + "요청 목록에 본인이 결제하지 않은 지출이 포함(ErrorCode=E400)"),
     })
-    public ResponseEntity<JeongsanApiResponse<Void>> changeExpensesStatusComplete(
+    ResponseEntity<JeongsanApiResponse<Void>> changeExpensesStatusComplete(
         CompleteExpensesRequest request, Long teamId, Long memberId);
 
+    @Operation(summary = "내가 지불한 지출 내역 조회 API", description = "내가 지불한 지출 내역 중 `송금 대기` 상태 지출 내역 조회")
+    @Parameter(name = "teamId", description = "조회를 원하는 모임 ID")
+    @ApiResponse(responseCode = "200", description = "지출 내역 목록을 성공적으로 조회")
+    ResponseEntity<JeongsanApiResponse<ExpenseResponse>> getExpensesIPaid(
+        Long memberId, Long teamId);
 }

--- a/src/main/java/kappzzang/jeongsan/repository/ExpenseRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/ExpenseRepository.java
@@ -52,4 +52,11 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
         "WHERE e.id IN :ids")
     List<Expense> findAllByIdWithDetails(List<Long> ids);
 
+    @Query("SELECT e FROM Expense e "
+        + "JOIN FETCH e.items "
+        + "WHERE e.team.id = :teamId "
+        + "AND e.payer.id = :memberId "
+        + "AND e.status = :status")
+    List<Expense> findExpensesIPaid(@Param("memberId") Long memberId, @Param("teamId") Long teamId,
+        @Param("status") Status status);
 }

--- a/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
@@ -65,6 +65,16 @@ public class ExpenseService {
         return ExpenseResponse.of(filteredExpenses, isChecked, totalPrice);
     }
 
+    @Transactional(readOnly = true)
+    public ExpenseResponse getExpensesIPaid(Long memberId, Long teamId) {
+        List<Expense> expenses = expenseRepository.findExpensesIPaid(memberId, teamId, Status.PENDING);
+        Integer totalPrice = expenses.stream()
+            .mapToInt(Expense::getTotalPrice)
+            .reduce(Integer::sum)
+            .orElse(0);
+        return ExpenseResponse.of(expenses, true, totalPrice);
+    }
+
     private List<Expense> filterOngoingExpenses(List<Expense> expenses, Long memberId,
         Boolean isChecked) {
         return expenses.stream()

--- a/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
@@ -344,6 +344,62 @@ public class ExpenseServiceTest {
             .hasMessage(ErrorType.EXPENSE_INVALID_PAYER.getMessage());
     }
 
+    @Test
+    @DisplayName("내가 지불한 지출 내역 - 빈 리스트")
+    void getExpensesIPaid_EmptyList() {
+        // given
+        Long memberId = 1L;
+        Long teamId = 1L;
+        given(mockExpenseRepository.findExpensesIPaid(memberId, teamId, Status.PENDING))
+            .willReturn(Collections.emptyList());
+
+        // when
+        ExpenseResponse response = expenseService.getExpensesIPaid(memberId, teamId);
+
+        // then
+        assertThat(response.expenseList()).isEmpty();
+        assertThat(response.totalPrice()).isEqualTo(0);
+        assertThat(response.checked()).isTrue();
+        then(mockExpenseRepository).should().findExpensesIPaid(memberId, teamId, Status.PENDING);
+    }
+
+    @Test
+    @DisplayName("내가 지불한 지출 내역 - 성공")
+    void getExpensesIPaid_Success() {
+        // given
+        Long memberId = 1L;
+        Long teamId = 1L;
+        Expense expense1 = mock(Expense.class);
+        Expense expense2 = mock(Expense.class);
+
+        given(expense1.getId()).willReturn(1L);
+        given(expense1.getTitle()).willReturn("Test Expense1");
+        given(expense1.getTotalPrice()).willReturn(1000);
+        given(expense1.getCreatedAt()).willReturn(LocalDateTime.now());
+        given(expense1.getStatus()).willReturn(Status.ONGOING);
+        given(expense1.getCategory()).willReturn(mock(Category.class));
+
+        given(expense2.getId()).willReturn(2L);
+        given(expense2.getTitle()).willReturn("Test Expense2");
+        given(expense2.getTotalPrice()).willReturn(2000);
+        given(expense2.getCreatedAt()).willReturn(LocalDateTime.now());
+        given(expense2.getStatus()).willReturn(Status.ONGOING);
+        given(expense2.getCategory()).willReturn(mock(Category.class));
+
+        List<Expense> expenses = List.of(expense1, expense2);
+        given(mockExpenseRepository.findExpensesIPaid(memberId, teamId, Status.PENDING))
+            .willReturn(expenses);
+
+        // when
+        ExpenseResponse response = expenseService.getExpensesIPaid(memberId, teamId);
+
+        // then
+        assertThat(response.expenseList()).hasSize(2);
+        assertThat(response.totalPrice()).isEqualTo(3000);
+        assertThat(response.checked()).isTrue();
+        then(mockExpenseRepository).should().findExpensesIPaid(memberId, teamId, Status.PENDING);
+    }
+
     private List<Expense> createExpenses(int count) {
         return IntStream.rangeClosed(1, count)
             .mapToObj(o -> Expense.builder()


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 내가 지불한 지출 중 `송금 대기`상태인 지출 내역 조회 api 구현
- 이 API에 대한 명세 및 테스트 코드 추가

### 🔍 참고 사항
- 

### ⚠️ 의논 필요
- 쿼리 파라미터를 이용해 `송금 대기` 상태 뿐만 아니라 다른 상태도 조회할 수 있도록 하는 것은 어떨까요?

### 🐞현재 버그
- 

### #️⃣ 연관 이슈(Git Close)
- close #97 
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
