### PR TITLE
Fix/issue#118: 회원가입 시 회원 정보가 두 번 저장되는 현상 수정

### DIFF
--- a/src/main/java/kappzzang/jeongsan/domain/Member.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Member.java
@@ -47,9 +47,4 @@ public class Member extends BaseEntity {
         this.refreshToken = refreshToken;
         this.kakaoPayInfo = kakaoPayInfo;
     }
-
-    public Member(String nickname, KakaoPayInfo kakaoPayInfo) {
-        this.nickname = nickname;
-        this.kakaoPayInfo = kakaoPayInfo;
-    }
 }

--- a/src/main/java/kappzzang/jeongsan/domain/Member.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Member.java
@@ -37,14 +37,17 @@ public class Member extends BaseEntity {
     @Embedded
     private KakaoPayInfo kakaoPayInfo;
 
-    @Builder(toBuilder = true)
-    public Member(Long id, String email, String nickname, String profileImage,
+    @Builder
+    public Member(String email, String nickname, String profileImage,
         String refreshToken, KakaoPayInfo kakaoPayInfo) {
-        this.id = id;
         this.email = email;
         this.nickname = nickname;
         this.profileImage = profileImage;
         this.refreshToken = refreshToken;
         this.kakaoPayInfo = kakaoPayInfo;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/kappzzang/jeongsan/domain/Member.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Member.java
@@ -38,8 +38,9 @@ public class Member extends BaseEntity {
     private KakaoPayInfo kakaoPayInfo;
 
     @Builder(toBuilder = true)
-    public Member(String email, String nickname, String profileImage,
+    public Member(Long id, String email, String nickname, String profileImage,
         String refreshToken, KakaoPayInfo kakaoPayInfo) {
+        this.id = id;
         this.email = email;
         this.nickname = nickname;
         this.profileImage = profileImage;

--- a/src/main/java/kappzzang/jeongsan/global/config/ApiClientConfig.java
+++ b/src/main/java/kappzzang/jeongsan/global/config/ApiClientConfig.java
@@ -46,12 +46,6 @@ public class ApiClientConfig {
                 openAiProperties.authType() + openAiProperties.key());
     }
 
-    @Bean
-    @Qualifier(value = "kakaoClientBuilder")
-    public RestClient.Builder kakaoClientBuilder() {
-        return getDefaultRestClientBuilder();
-    }
-
     private RestClient.Builder getDefaultRestClientBuilder() {
         ClientHttpRequestFactorySettings settings = ClientHttpRequestFactorySettings.DEFAULTS
             .withConnectTimeout(Duration.ofMillis(apiTimeout))

--- a/src/main/java/kappzzang/jeongsan/service/MemberService.java
+++ b/src/main/java/kappzzang/jeongsan/service/MemberService.java
@@ -56,9 +56,7 @@ public class MemberService {
     private LoginResponse createToken(Member member) {
         String accessToken = jwtUtil.createAccessToken(member.getId());
         String refreshToken = jwtUtil.createRefreshToken();
-        member = member.toBuilder()
-            .refreshToken(refreshToken)
-            .build();
+        member.updateRefreshToken(refreshToken);
         memberRepository.save(member);
 
         return new LoginResponse(BEARER, accessToken, refreshToken);

--- a/src/test/java/kappzzang/jeongsan/service/MemberServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/MemberServiceTest.java
@@ -65,7 +65,7 @@ public class MemberServiceTest {
     @DisplayName("로그인 성공")
     void login() {
         // given
-        given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(createMember()));
+        given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(createMember(null)));
         given(jwtUtil.createAccessToken(any())).willReturn(TEST_ACCESS_TOKEN);
         given(jwtUtil.createRefreshToken()).willReturn(TEST_REFRESH_TOKEN);
 
@@ -85,7 +85,7 @@ public class MemberServiceTest {
         // given
         RegisterRequest registerRequest = new RegisterRequest(TEST_NICKNAME, TEST_EMAIL,
             TEST_PROFILE_IMAGE);
-        given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(createMember()));
+        given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(createMember(null)));
 
         // when & then
         assertThatThrownBy(() -> memberService.register(registerRequest))
@@ -100,7 +100,7 @@ public class MemberServiceTest {
         RegisterRequest registerRequest = new RegisterRequest(TEST_NICKNAME, TEST_EMAIL,
             TEST_PROFILE_IMAGE);
         given(memberRepository.findByEmail(anyString())).willReturn(Optional.empty());
-        given(memberRepository.save(any(Member.class))).willReturn(createMember());
+        given(memberRepository.save(any(Member.class))).willReturn(createMember(null));
         given(jwtUtil.createAccessToken(any())).willReturn(TEST_ACCESS_TOKEN);
         given(jwtUtil.createRefreshToken()).willReturn(TEST_REFRESH_TOKEN);
 
@@ -119,7 +119,7 @@ public class MemberServiceTest {
     void refreshWithMismatchedRefreshToken() {
         // given
         RefreshRequest refreshRequest = new RefreshRequest("RefreshToken");
-        given(memberRepository.findById(anyLong())).willReturn(Optional.of(createMember()));
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(createMember(null)));
 
         // when & then
         assertThatThrownBy(() -> memberService.refresh(anyLong(), refreshRequest))
@@ -132,7 +132,7 @@ public class MemberServiceTest {
     void refreshWithInvalidRefreshToken() {
         // given
         RefreshRequest refreshRequest = new RefreshRequest(TEST_REFRESH_TOKEN);
-        given(memberRepository.findById(anyLong())).willReturn(Optional.of(createMember()));
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(createMember(null)));
         given(jwtUtil.validateRefreshToken(TEST_REFRESH_TOKEN)).willReturn(false);
 
         // when & then
@@ -146,7 +146,7 @@ public class MemberServiceTest {
     void refresh() {
         // given
         RefreshRequest refreshRequest = new RefreshRequest(TEST_REFRESH_TOKEN);
-        given(memberRepository.findById(anyLong())).willReturn(Optional.of(createMember()));
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(createMember(null)));
         given(jwtUtil.validateRefreshToken(TEST_REFRESH_TOKEN)).willReturn(true);
         given(jwtUtil.createAccessToken(anyLong())).willReturn(TEST_ACCESS_TOKEN);
 
@@ -164,7 +164,7 @@ public class MemberServiceTest {
         // given
         KakaoPayInfo kakaoPayInfo = new KakaoPayInfo("payLink");
         given(memberRepository.findById(anyLong())).willReturn(
-            Optional.of(new Member("member", kakaoPayInfo)));
+            Optional.of(createMember(kakaoPayInfo)));
 
         // when
         GetPayLinkResponse getPayLinkResponse = memberService.getPayLink(1L);
@@ -179,14 +179,16 @@ public class MemberServiceTest {
         // given
         KakaoPayInfo kakaoPayInfo = new KakaoPayInfo(null);
         given(memberRepository.findById(anyLong())).willReturn(
-            Optional.of(new Member("member", kakaoPayInfo)));
+            Optional.of(createMember(kakaoPayInfo)));
 
         // when, then
         assertThrows(JeongsanException.class, () -> memberService.getPayLink(1L));
     }
 
-    private Member createMember() {
+    private Member createMember(KakaoPayInfo kakaoPayInfo) {
         return Member.builder()
+            .nickname("member")
+            .kakaoPayInfo(kakaoPayInfo)
             .refreshToken(TEST_REFRESH_TOKEN)
             .build();
     }

--- a/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
@@ -63,11 +63,20 @@ class PersonalExpenseServiceTest {
     void setup() {
         team = teamRepository.save(new Team("Test Team", "🍎"));
         member1 = memberRepository.save(
-            new Member("email1@test.com", "User1", null, null, null));
+            Member.builder()
+                .email("email1@test.com")
+                .nickname("User1")
+                .build());
         member2 = memberRepository.save(
-            new Member("email2@test.com", "User2", null, null, null));
+            Member.builder()
+                .email("email2@test.com")
+                .nickname("User2")
+                .build());
         member3 = memberRepository.save(
-            new Member("email3@test.com", "User3", null, null, null));
+            Member.builder()
+                .email("email3@test.com")
+                .nickname("User3")
+                .build());
         item1 = new Item("Test Item", 2, 1000);
         item2 = new Item("Test Item", 1, 1000);
         expense = Expense.builder()


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- ~Member 도메인 빌더 수정~ -> refreshToken 설정 메서드 추가
- 사용하지 않는 ClientBuilder 삭제

### 🔍 참고 사항
- toBuilder를 이용하여 refreshToken을 저장하는데, 빌더에 id가 없었기에 새로운 엔티티로 저장되었습니다.
- toBuilder 대신 refreshToken을 설정하는 메서드를 추가하였습니다.

### ⚠️ 의논 필요
X

### 🐞현재 버그
X

### #️⃣ 연관 이슈(Git Close)
- close #118 
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
