### PR TITLE
Feature/issue#113: teamId를 이용한 모임 조회

### DIFF
--- a/src/main/java/kappzzang/jeongsan/controller/TeamController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/TeamController.java
@@ -38,6 +38,12 @@ public class TeamController implements TeamControllerInterface {
         return JeongsanApiResponse.success(SuccessType.TEAM_LIST_LOADED, data);
     }
 
+    @GetMapping("{teamId}")
+    public ResponseEntity<JeongsanApiResponse<TeamResponse>> getTeam(@PathVariable Long teamId) {
+        TeamResponse data = teamService.getTeam(teamId);
+        return JeongsanApiResponse.success(SuccessType.TEAM_LIST_LOADED, data);
+    }
+
     @Override
     @PostMapping
     public ResponseEntity<JeongsanApiResponse<CreateTeamResponse>> createTeam(

--- a/src/main/java/kappzzang/jeongsan/controller/TeamController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/TeamController.java
@@ -38,6 +38,7 @@ public class TeamController implements TeamControllerInterface {
         return JeongsanApiResponse.success(SuccessType.TEAM_LIST_LOADED, data);
     }
 
+    @Override
     @GetMapping("{teamId}")
     public ResponseEntity<JeongsanApiResponse<TeamResponse>> getTeam(@PathVariable Long teamId) {
         TeamResponse data = teamService.getTeam(teamId);

--- a/src/main/java/kappzzang/jeongsan/controller/docs/TeamControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/TeamControllerInterface.java
@@ -45,7 +45,6 @@ public interface TeamControllerInterface {
     @ApiResponses({
         @ApiResponse(responseCode = "201", description = "모임 생성 성공"),
         @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음(ErrorCode-E404001)"),
-        @ApiResponse(responseCode = "409", description = "중복된 모임 이름이 존재함(ErrorCode-E409001)")
     })
     ResponseEntity<JeongsanApiResponse<CreateTeamResponse>> createTeam(Long memberId,
         CreateTeamRequest request);

--- a/src/main/java/kappzzang/jeongsan/controller/docs/TeamControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/TeamControllerInterface.java
@@ -27,6 +27,15 @@ public interface TeamControllerInterface {
     })
     ResponseEntity<JeongsanApiResponse<List<TeamResponse>>> getTeams(Boolean isClosed);
 
+    @Operation(summary = "모임 조회 API", description = "`teamId`를 이용해 모임을 조회하는 API")
+    @Parameter(name = "teamId", description = "조회를 원하는 모임의 ID")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "모임 목록 조회 성공",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = TeamResponse.class))),
+        @ApiResponse(responseCode = "404", description = "해당하는 모임을 찾을 수 없음(ErrorCode-E404)")
+    })
+    ResponseEntity<JeongsanApiResponse<TeamResponse>> getTeam(Long teamId);
+
     @Operation(summary = "모임 생성 API", description = "요청한 사용자가 주인으로 모임을 생성하는 API")
     @Parameters({
         @Parameter(name = "name", description = "15글자 이내의 모임 이름. 모임의 owner 기준 동일한 모임 이름을 사용할 수 없음"),

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
@@ -9,6 +9,7 @@ public enum SuccessType {
 
     // 200 OK
     TEAM_LIST_LOADED(HttpStatus.OK, "모임 목록을 불러오는 데 성공했습니다."),
+    TEAM_LOADED(HttpStatus.OK, "모임을 불러오는 데 성공했습니다"),
     RECEIPT_ANALYSIS_SUCCESS(HttpStatus.OK, "영수증 분석을 성공하였습니다."),
     EXPENSE_LIST_LOADED(HttpStatus.OK, "지출 목록을 불러오는 데 성공했습니다"),
     PERSONAL_EXPENSE_LOADED(HttpStatus.OK, "개인 지출 목록을 불러오는 데 성공했습니다."),

--- a/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
@@ -4,7 +4,6 @@ import java.util.List;
 import kappzzang.jeongsan.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
 
@@ -13,10 +12,4 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
         "JOIN FETCH tm.member " +
         "WHERE t.isClosed = :isClosed")
     List<Team> findByIsClosed(Boolean isClosed);
-
-    @Query("SELECT CASE WHEN COUNT(t) > 0 THEN TRUE ELSE FALSE END "
-        + "FROM Team t "
-        + "JOIN TeamMember tm ON t.id = tm.team.id "
-        + "WHERE t.name = :name AND tm.member.id = :memberId")
-    Boolean existsByNameAndMemberId(@Param("name") String name, @Param("memberId") Long memberId);
 }

--- a/src/main/java/kappzzang/jeongsan/service/TeamService.java
+++ b/src/main/java/kappzzang/jeongsan/service/TeamService.java
@@ -42,10 +42,6 @@ public class TeamService {
 
     @Transactional
     public CreateTeamResponse createTeam(Long memberId, CreateTeamRequest request) {
-        if (teamRepository.existsByNameAndMemberId(request.name(), memberId)) {
-            throw new JeongsanException(ErrorType.TEAM_NAME_DUPLICATED);
-        }
-
         Member owner = memberRepository.findById(memberId)
             .orElseThrow(() -> new JeongsanException(ErrorType.USER_NOT_FOUND));
 

--- a/src/main/java/kappzzang/jeongsan/service/TeamService.java
+++ b/src/main/java/kappzzang/jeongsan/service/TeamService.java
@@ -34,6 +34,12 @@ public class TeamService {
             .toList();
     }
 
+    @Transactional(readOnly = true)
+    public TeamResponse getTeam(Long id) {
+        return TeamResponse.from(teamRepository.findById(id)
+            .orElseThrow(() -> new JeongsanException(ErrorType.TEAM_NOT_FOUND)));
+    }
+
     @Transactional
     public CreateTeamResponse createTeam(Long memberId, CreateTeamRequest request) {
         if (teamRepository.existsByNameAndMemberId(request.name(), memberId)) {

--- a/src/test/java/kappzzang/jeongsan/service/TeamServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/TeamServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -17,6 +18,7 @@ import kappzzang.jeongsan.domain.Team;
 import kappzzang.jeongsan.dto.request.CreateTeamRequest;
 import kappzzang.jeongsan.dto.response.CreateTeamResponse;
 import kappzzang.jeongsan.dto.response.InvitationStatusResponse;
+import kappzzang.jeongsan.dto.response.TeamResponse;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
 import kappzzang.jeongsan.global.exception.JeongsanException;
 import kappzzang.jeongsan.repository.MemberRepository;
@@ -145,5 +147,39 @@ class TeamServiceTest {
         then(memberRepository).should().findById(memberId1);
         then(memberRepository).should().findById(memberId2);
         then(memberRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("잘못된 teamId를 이용한 조회로 notfound 발생")
+    void getTeam_NotFound() {
+        // given
+        given(teamRepository.findById(any(Long.class))).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> teamService.getTeam(1L))
+            .isInstanceOf(JeongsanException.class).hasMessageContaining("찾을 수 없습니다.");
+        then(teamRepository).should().findById(any(Long.class));
+    }
+
+    @Test
+    @DisplayName("teamId를 이용한 조회 성공")
+    void getTeam_success() {
+        // given
+        String teamName = "Test Team";
+        Team team = mock(Team.class);
+
+        given(team.getId()).willReturn(1L);
+        given(team.getName()).willReturn(teamName);
+        given(team.getIsClosed()).willReturn(false);
+        given(team.getSubject()).willReturn("subject");
+        given(team.getTeamMemberList()).willReturn(Collections.emptyList());
+        given(teamRepository.findById(1L)).willReturn(Optional.of(team));
+
+        // when
+        TeamResponse actual = teamService.getTeam(1L);
+
+        // then
+        assertThat(actual).isNotNull();
+        then(teamRepository).should().findById(1L);
     }
 }

--- a/src/test/java/kappzzang/jeongsan/service/TeamServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/TeamServiceTest.java
@@ -96,22 +96,6 @@ class TeamServiceTest {
     }
 
     @Test
-    @DisplayName("모임 생성자에게 동일한 모임 이름이 존재")
-    void createTeam_NameDuplicateException() {
-        // given
-        Long memberId = 1L;
-        String teamName = "Test Team";
-        given(teamRepository.existsByNameAndMemberId(teamName, memberId)).willReturn(true);
-
-        // when & then
-        assertThatThrownBy(() ->
-            teamService.createTeam(memberId,
-                new CreateTeamRequest(teamName, "subject", new ArrayList<>()))
-        ).isInstanceOf(JeongsanException.class);
-        then(teamRepository).should().existsByNameAndMemberId(teamName, memberId);
-    }
-
-    @Test
     @DisplayName("모임 생성 성공")
     void createTeam_Success() {
         // given
@@ -127,7 +111,6 @@ class TeamServiceTest {
         List<Member> members = new ArrayList<>(Arrays.asList(member1, member2));
         Team team = Team.createTeam(owner, teamName, "subject", members);
 
-        given(teamRepository.existsByNameAndMemberId(teamName, ownerId)).willReturn(false);
         given(teamRepository.save(any(Team.class))).willReturn(team);
         given(memberRepository.findById(ownerId)).willReturn(Optional.of(owner));
         given(memberRepository.findById(memberId1)).willReturn(Optional.of(member1));
@@ -139,7 +122,6 @@ class TeamServiceTest {
         // then
         assertThat(actual).isNotNull();
 
-        then(teamRepository).should().existsByNameAndMemberId(teamName, ownerId);
         then(teamRepository).should().save(any(Team.class));
         then(teamRepository).shouldHaveNoMoreInteractions();
 


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- `GET /api/teams/{teamId}` 조회 구현
- 추가적으로 모임 생성 시 중복 이름 검증 로직이 아직 남아있어 삭제했습니다

### #️⃣ 연관 이슈(Git Close)
close #113 
___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
