### PR TITLE
Feature/issue#122: expenseService 로직 중 teamId, memberId를 사용하는 부분 유효성 검증 추가

### DIFF
--- a/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
@@ -70,7 +70,10 @@ public interface ExpenseControllerInterface {
 
     @Operation(summary = "내가 지불한 지출 내역 조회 API", description = "내가 지불한 지출 내역 중 `송금 대기` 상태 지출 내역 조회")
     @Parameter(name = "teamId", description = "조회를 원하는 모임 ID")
-    @ApiResponse(responseCode = "200", description = "지출 내역 목록을 성공적으로 조회")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "지출 내역 목록을 성공적으로 조회"),
+        @ApiResponse(responseCode = "404", description = "`teamId`에 해당하는 모임이 존재하지 않음. (ErrorCode-E404002)")
+    })
     ResponseEntity<JeongsanApiResponse<ExpenseResponse>> getExpensesIPaid(
         Long memberId, Long teamId);
 }

--- a/src/main/java/kappzzang/jeongsan/repository/ExpenseRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/ExpenseRepository.java
@@ -2,6 +2,8 @@ package kappzzang.jeongsan.repository;
 
 import java.util.List;
 import kappzzang.jeongsan.domain.Expense;
+import kappzzang.jeongsan.domain.Member;
+import kappzzang.jeongsan.domain.Team;
 import kappzzang.jeongsan.dto.ItemDetail;
 import kappzzang.jeongsan.global.common.enumeration.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -54,9 +56,9 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
     @Query("SELECT e FROM Expense e "
         + "JOIN FETCH e.items "
-        + "WHERE e.team.id = :teamId "
-        + "AND e.payer.id = :memberId "
+        + "WHERE e.team = :team "
+        + "AND e.payer = :payer "
         + "AND e.status = :status")
-    List<Expense> findExpensesIPaid(@Param("memberId") Long memberId, @Param("teamId") Long teamId,
+    List<Expense> findExpensesIPaid(@Param("payer") Member payer, @Param("team") Team team,
         @Param("status") Status status);
 }

--- a/src/main/java/kappzzang/jeongsan/repository/ExpenseRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/ExpenseRepository.java
@@ -14,9 +14,9 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
     @Query("SELECT e FROM Expense e "
         + "JOIN FETCH e.items "
-        + "WHERE e.team.id = :teamId "
+        + "WHERE e.team = :team "
         + "AND e.status = :status")
-    List<Expense> findByTeamIdAndStatus(Long teamId, Status status);
+    List<Expense> findByTeamAndStatus(Team team, Status status);
 
 //    @Query("SELECT e FROM Expense e "
 //        + "WHERE e.team.id = :teamId "

--- a/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
@@ -67,7 +67,9 @@ public class ExpenseService {
 
     @Transactional(readOnly = true)
     public ExpenseResponse getExpensesIPaid(Long memberId, Long teamId) {
-        List<Expense> expenses = expenseRepository.findExpensesIPaid(memberId, teamId, Status.PENDING);
+        Member payer = findMemberById(memberId);
+        Team team = findTeamById(teamId);
+        List<Expense> expenses = expenseRepository.findExpensesIPaid(payer, team, Status.PENDING);
         Integer totalPrice = expenses.stream()
             .mapToInt(Expense::getTotalPrice)
             .reduce(Integer::sum)

--- a/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/ExpenseService.java
@@ -45,7 +45,8 @@ public class ExpenseService {
     @Transactional(readOnly = true)
     public ExpenseResponse getExpenses(Long memberId, Long teamId, Status status,
         Boolean isChecked) {
-        List<Expense> expenses = expenseRepository.findByTeamIdAndStatus(teamId, status);
+        Team team = findTeamById(teamId);
+        List<Expense> expenses = expenseRepository.findByTeamAndStatus(team, status);
 
         Map<Status, Function<List<Expense>, List<Expense>>> filteringStrategies = Map.of(
             Status.ONGOING, expenseList -> filterOngoingExpenses(expenseList, memberId, isChecked),

--- a/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
@@ -64,16 +64,16 @@ public class ExpenseServiceTest {
     private TeamRepository teamRepository;
 
     @Mock
-    private ImageStorageService mockImageStorageService;
+    private ImageStorageService imageStorageService;
 
     @Mock
-    private ExpenseRepository mockExpenseRepository;
+    private ExpenseRepository expenseRepository;
 
     @Mock
-    private ItemRepository mockItemRepository;
+    private ItemRepository itemRepository;
 
     @Mock
-    private PersonalExpenseRepository mockPersonalExpenseRepository;
+    private PersonalExpenseRepository personalExpenseRepository;
 
     @InjectMocks
     private ExpenseService expenseService;
@@ -103,12 +103,12 @@ public class ExpenseServiceTest {
         PersonalExpenseDetailResponse expected = new PersonalExpenseDetailResponse(
             expense.getTitle(), TEST_PRE_SIGNED_URL, itemDetails);
 
-        given(mockExpenseRepository.findById(TEST_EXPENSE_ID)).willReturn(
+        given(expenseRepository.findById(TEST_EXPENSE_ID)).willReturn(
             Optional.ofNullable(expense));
-        given(mockExpenseRepository.findItemDetailsByExpenseIdAndMemberId(TEST_EXPENSE_ID,
+        given(expenseRepository.findItemDetailsByExpenseIdAndMemberId(TEST_EXPENSE_ID,
             TEST_MEMBER_ID)).willReturn(
             itemDetails);
-        given(mockImageStorageService.getImageUrl(TEST_IMAGE_URL)).willReturn(TEST_PRE_SIGNED_URL);
+        given(imageStorageService.getImageUrl(TEST_IMAGE_URL)).willReturn(TEST_PRE_SIGNED_URL);
 
         //when
         PersonalExpenseDetailResponse actual = expenseService.getPersonalExpenseDetailResponse(
@@ -117,17 +117,17 @@ public class ExpenseServiceTest {
 
         //then
         assertThat(actual).isEqualTo(expected);
-        then(mockExpenseRepository).should().findById(TEST_EXPENSE_ID);
-        then(mockExpenseRepository).should().findItemDetailsByExpenseIdAndMemberId(TEST_EXPENSE_ID,
+        then(expenseRepository).should().findById(TEST_EXPENSE_ID);
+        then(expenseRepository).should().findItemDetailsByExpenseIdAndMemberId(TEST_EXPENSE_ID,
             TEST_MEMBER_ID);
-        then(mockImageStorageService).should().getImageUrl(TEST_IMAGE_URL);
+        then(imageStorageService).should().getImageUrl(TEST_IMAGE_URL);
     }
 
     @Test
     @DisplayName("개인 지출 목록 조회 실패(존재하지 않는 지출 ID)")
     void testGetPersonalExpenseDetailResponseFailWithNotFoundExpense() {
         //given
-        given(mockExpenseRepository.findById(TEST_EXPENSE_ID)).willThrow(new JeongsanException(
+        given(expenseRepository.findById(TEST_EXPENSE_ID)).willThrow(new JeongsanException(
             ErrorType.EXPENSE_NOT_FOUND));
 
         //when //then
@@ -136,7 +136,7 @@ public class ExpenseServiceTest {
         )
             .isInstanceOf(JeongsanException.class)
             .hasMessage(ErrorType.EXPENSE_NOT_FOUND.getMessage());
-        then(mockExpenseRepository).should().findById(TEST_EXPENSE_ID);
+        then(expenseRepository).should().findById(TEST_EXPENSE_ID);
     }
 
 
@@ -153,12 +153,12 @@ public class ExpenseServiceTest {
         List<Expense> expenses = Collections.singletonList(expense);
         List<Item> items = Collections.singletonList(item);
 
-        given(mockExpenseRepository.findByTeamAndStatus(mockTeam, status)).willReturn(expenses);
+        given(expenseRepository.findByTeamAndStatus(mockTeam, status)).willReturn(expenses);
         given(teamRepository.findById(any(Long.class))).willReturn(Optional.of(mockTeam));
 
-        given(mockExpenseRepository.findByTeamAndStatus(mockTeam, status)).willReturn(expenses);
-        given(mockItemRepository.findAllByExpenseId(expense.getId())).willReturn(items);
-        given(mockPersonalExpenseRepository.countByMemberIdAndItemIds(memberId,
+        given(expenseRepository.findByTeamAndStatus(mockTeam, status)).willReturn(expenses);
+        given(itemRepository.findAllByExpenseId(expense.getId())).willReturn(items);
+        given(personalExpenseRepository.countByMemberIdAndItemIds(memberId,
             items.stream().map(Item::getId).toList())).willReturn(0L);
 
         // when
@@ -169,8 +169,8 @@ public class ExpenseServiceTest {
         assertThat(response.totalPrice()).isEqualTo(0);
         assertThat(response.checked()).isTrue();
 
-        then(mockExpenseRepository).should().findByTeamAndStatus(mockTeam, status);
-        then(mockItemRepository).should().findAllByExpenseId(expense.getId());
+        then(expenseRepository).should().findByTeamAndStatus(mockTeam, status);
+        then(itemRepository).should().findAllByExpenseId(expense.getId());
     }
 
     @Test
@@ -184,7 +184,7 @@ public class ExpenseServiceTest {
         Expense expense = mock(Expense.class);
         List<Expense> expenses = Collections.singletonList(expense);
 
-        given(mockExpenseRepository.findByTeamAndStatus(mockTeam, status)).willReturn(expenses);
+        given(expenseRepository.findByTeamAndStatus(mockTeam, status)).willReturn(expenses);
         given(teamRepository.findById(any(Long.class))).willReturn(Optional.of(mockTeam));
 
         given(expense.getId()).willReturn(1L);
@@ -224,12 +224,12 @@ public class ExpenseServiceTest {
         given(expense.getStatus()).willReturn(Status.COMPLETED);
         given(expense.getCategory()).willReturn(mock(Category.class));
 
-        given(mockExpenseRepository.findByTeamAndStatus(mockTeam, status)).willReturn(expenses);
+        given(expenseRepository.findByTeamAndStatus(mockTeam, status)).willReturn(expenses);
         given(teamRepository.findById(any(Long.class))).willReturn(Optional.of(mockTeam));
 
-        given(mockExpenseRepository.findByTeamAndStatus(mockTeam, status)).willReturn(expenses);
-        given(mockItemRepository.findAllByExpenseId(expense.getId())).willReturn(items);
-        given(mockPersonalExpenseRepository.countByMemberIdAndItemIds(memberId,
+        given(expenseRepository.findByTeamAndStatus(mockTeam, status)).willReturn(expenses);
+        given(itemRepository.findAllByExpenseId(expense.getId())).willReturn(items);
+        given(personalExpenseRepository.countByMemberIdAndItemIds(memberId,
             items.stream().map(Item::getId).toList())).willReturn(1L);
 
         // when
@@ -251,14 +251,14 @@ public class ExpenseServiceTest {
         given(mockTeam.getId()).willReturn(TEST_TEAM_ID);
         given(mockPayer.getId()).willReturn(TEST_MEMBER_ID);
         given(
-            mockExpenseRepository.findAllByIdWithDetails(expenseIds)).willReturn(
+            expenseRepository.findAllByIdWithDetails(expenseIds)).willReturn(
             expenses);
         //when
         expenseService.completeExpenses(completeExpensesRequest, TEST_TEAM_ID, TEST_MEMBER_ID);
 
         //then
         assertThat(expenses).extracting(Expense::getStatus).containsOnly(Status.COMPLETED);
-        then(mockExpenseRepository).should()
+        then(expenseRepository).should()
             .findAllByIdWithDetails(expenseIds);
     }
 
@@ -272,7 +272,7 @@ public class ExpenseServiceTest {
         given(mockTeam.getId()).willReturn(TEST_TEAM_ID);
         given(mockPayer.getId()).willReturn(TEST_MEMBER_ID);
         given(
-            mockExpenseRepository.findAllByIdWithDetails(expenseIds)).willReturn(
+            expenseRepository.findAllByIdWithDetails(expenseIds)).willReturn(
             expenses);
         expenses.getFirst().changeStatusComplete(TEST_TEAM_ID, TEST_MEMBER_ID);
 
@@ -290,7 +290,7 @@ public class ExpenseServiceTest {
         //given
         List<Expense> expenses = createExpenses(TEST_EXPENSES_SIZE - 1);
         given(
-            mockExpenseRepository.findAllByIdWithDetails(expenseIds)).willReturn(
+            expenseRepository.findAllByIdWithDetails(expenseIds)).willReturn(
             expenses);
 
         //when //then
@@ -307,7 +307,7 @@ public class ExpenseServiceTest {
         //given
         List<Expense> expenses = createExpenses(TEST_EXPENSES_SIZE);
         given(
-            mockExpenseRepository.findAllByIdWithDetails(expenseIds)).willReturn(
+            expenseRepository.findAllByIdWithDetails(expenseIds)).willReturn(
             expenses);
         given(mockTeam.getId()).willReturn(TEST_TEAM_ID);
         given(mockPayer.getId()).willReturn(TEST_MEMBER_ID);
@@ -328,7 +328,7 @@ public class ExpenseServiceTest {
         List<Expense> expenses = createExpenses(TEST_EXPENSES_SIZE);
         expenses.forEach(Expense::changeStatusPending);
         given(
-            mockExpenseRepository.findAllByIdWithDetails(expenseIds)).willReturn(
+            expenseRepository.findAllByIdWithDetails(expenseIds)).willReturn(
             expenses);
         given(mockTeam.getId()).willReturn(INVALID_TEAM_ID);
         //when //then
@@ -348,7 +348,7 @@ public class ExpenseServiceTest {
         List<Expense> expenses = createExpenses(TEST_EXPENSES_SIZE);
         expenses.forEach(Expense::changeStatusPending);
         given(
-            mockExpenseRepository.findAllByIdWithDetails(expenseIds)).willReturn(
+            expenseRepository.findAllByIdWithDetails(expenseIds)).willReturn(
             expenses);
         given(mockTeam.getId()).willReturn(TEST_TEAM_ID);
         given(mockPayer.getId()).willReturn(INVALID_MEMBER_ID);
@@ -367,7 +367,7 @@ public class ExpenseServiceTest {
         // given
         Member member = new Member();
         Team team = new Team();
-        given(mockExpenseRepository.findExpensesIPaid(member, team, Status.PENDING))
+        given(expenseRepository.findExpensesIPaid(member, team, Status.PENDING))
             .willReturn(Collections.emptyList());
         given(teamRepository.findById(any(Long.class))).willReturn(Optional.of(team));
         given(memberRepository.findById(any(Long.class))).willReturn(Optional.of(member));
@@ -379,7 +379,7 @@ public class ExpenseServiceTest {
         assertThat(response.expenseList()).isEmpty();
         assertThat(response.totalPrice()).isEqualTo(0);
         assertThat(response.checked()).isTrue();
-        then(mockExpenseRepository).should().findExpensesIPaid(member, team, Status.PENDING);
+        then(expenseRepository).should().findExpensesIPaid(member, team, Status.PENDING);
     }
 
     @Test
@@ -408,7 +408,7 @@ public class ExpenseServiceTest {
         List<Expense> expenses = List.of(expense1, expense2);
         given(teamRepository.findById(any(Long.class))).willReturn(Optional.of(mockTeam));
         given(memberRepository.findById(any(Long.class))).willReturn(Optional.of(mockPayer));
-        given(mockExpenseRepository.findExpensesIPaid(mockPayer, mockTeam, Status.PENDING))
+        given(expenseRepository.findExpensesIPaid(mockPayer, mockTeam, Status.PENDING))
             .willReturn(expenses);
 
         // when
@@ -418,7 +418,7 @@ public class ExpenseServiceTest {
         assertThat(response.expenseList()).hasSize(2);
         assertThat(response.totalPrice()).isEqualTo(3000);
         assertThat(response.checked()).isTrue();
-        then(mockExpenseRepository).should().findExpensesIPaid(mockPayer, mockTeam, Status.PENDING);
+        then(expenseRepository).should().findExpensesIPaid(mockPayer, mockTeam, Status.PENDING);
     }
 
     private List<Expense> createExpenses(int count) {

--- a/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
@@ -2,6 +2,7 @@ package kappzzang.jeongsan.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
@@ -27,7 +28,9 @@ import kappzzang.jeongsan.global.common.enumeration.Status;
 import kappzzang.jeongsan.global.exception.JeongsanException;
 import kappzzang.jeongsan.repository.ExpenseRepository;
 import kappzzang.jeongsan.repository.ItemRepository;
+import kappzzang.jeongsan.repository.MemberRepository;
 import kappzzang.jeongsan.repository.PersonalExpenseRepository;
+import kappzzang.jeongsan.repository.TeamRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -53,6 +56,12 @@ public class ExpenseServiceTest {
     private final Team mockTeam = mock(Team.class);
     private List<Long> expenseIds;
     private CompleteExpensesRequest completeExpensesRequest;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private TeamRepository teamRepository;
 
     @Mock
     private ImageStorageService mockImageStorageService;
@@ -348,19 +357,21 @@ public class ExpenseServiceTest {
     @DisplayName("내가 지불한 지출 내역 - 빈 리스트")
     void getExpensesIPaid_EmptyList() {
         // given
-        Long memberId = 1L;
-        Long teamId = 1L;
-        given(mockExpenseRepository.findExpensesIPaid(memberId, teamId, Status.PENDING))
+        Member member = new Member();
+        Team team = new Team();
+        given(mockExpenseRepository.findExpensesIPaid(member, team, Status.PENDING))
             .willReturn(Collections.emptyList());
+        given(teamRepository.findById(any(Long.class))).willReturn(Optional.of(team));
+        given(memberRepository.findById(any(Long.class))).willReturn(Optional.of(member));
 
         // when
-        ExpenseResponse response = expenseService.getExpensesIPaid(memberId, teamId);
+        ExpenseResponse response = expenseService.getExpensesIPaid(TEST_MEMBER_ID, TEST_TEAM_ID);
 
         // then
         assertThat(response.expenseList()).isEmpty();
         assertThat(response.totalPrice()).isEqualTo(0);
         assertThat(response.checked()).isTrue();
-        then(mockExpenseRepository).should().findExpensesIPaid(memberId, teamId, Status.PENDING);
+        then(mockExpenseRepository).should().findExpensesIPaid(member, team, Status.PENDING);
     }
 
     @Test
@@ -387,7 +398,9 @@ public class ExpenseServiceTest {
         given(expense2.getCategory()).willReturn(mock(Category.class));
 
         List<Expense> expenses = List.of(expense1, expense2);
-        given(mockExpenseRepository.findExpensesIPaid(memberId, teamId, Status.PENDING))
+        given(teamRepository.findById(any(Long.class))).willReturn(Optional.of(mockTeam));
+        given(memberRepository.findById(any(Long.class))).willReturn(Optional.of(mockPayer));
+        given(mockExpenseRepository.findExpensesIPaid(mockPayer, mockTeam, Status.PENDING))
             .willReturn(expenses);
 
         // when
@@ -397,7 +410,7 @@ public class ExpenseServiceTest {
         assertThat(response.expenseList()).hasSize(2);
         assertThat(response.totalPrice()).isEqualTo(3000);
         assertThat(response.checked()).isTrue();
-        then(mockExpenseRepository).should().findExpensesIPaid(memberId, teamId, Status.PENDING);
+        then(mockExpenseRepository).should().findExpensesIPaid(mockPayer, mockTeam, Status.PENDING);
     }
 
     private List<Expense> createExpenses(int count) {

--- a/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
@@ -153,7 +153,10 @@ public class ExpenseServiceTest {
         List<Expense> expenses = Collections.singletonList(expense);
         List<Item> items = Collections.singletonList(item);
 
-        given(mockExpenseRepository.findByTeamIdAndStatus(teamId, status)).willReturn(expenses);
+        given(mockExpenseRepository.findByTeamAndStatus(mockTeam, status)).willReturn(expenses);
+        given(teamRepository.findById(any(Long.class))).willReturn(Optional.of(mockTeam));
+
+        given(mockExpenseRepository.findByTeamAndStatus(mockTeam, status)).willReturn(expenses);
         given(mockItemRepository.findAllByExpenseId(expense.getId())).willReturn(items);
         given(mockPersonalExpenseRepository.countByMemberIdAndItemIds(memberId,
             items.stream().map(Item::getId).toList())).willReturn(0L);
@@ -166,7 +169,7 @@ public class ExpenseServiceTest {
         assertThat(response.totalPrice()).isEqualTo(0);
         assertThat(response.checked()).isTrue();
 
-        then(mockExpenseRepository).should().findByTeamIdAndStatus(teamId, status);
+        then(mockExpenseRepository).should().findByTeamAndStatus(mockTeam, status);
         then(mockItemRepository).should().findAllByExpenseId(expense.getId());
     }
 
@@ -181,7 +184,9 @@ public class ExpenseServiceTest {
         Expense expense = mock(Expense.class);
         List<Expense> expenses = Collections.singletonList(expense);
 
-        given(mockExpenseRepository.findByTeamIdAndStatus(teamId, status)).willReturn(expenses);
+        given(mockExpenseRepository.findByTeamAndStatus(mockTeam, status)).willReturn(expenses);
+        given(teamRepository.findById(any(Long.class))).willReturn(Optional.of(mockTeam));
+
         given(expense.getId()).willReturn(1L);
         given(expense.getTitle()).willReturn("Test Expense");
         given(expense.getTotalPrice()).willReturn(1000);
@@ -219,7 +224,10 @@ public class ExpenseServiceTest {
         given(expense.getStatus()).willReturn(Status.COMPLETED);
         given(expense.getCategory()).willReturn(mock(Category.class));
 
-        given(mockExpenseRepository.findByTeamIdAndStatus(teamId, status)).willReturn(expenses);
+        given(mockExpenseRepository.findByTeamAndStatus(mockTeam, status)).willReturn(expenses);
+        given(teamRepository.findById(any(Long.class))).willReturn(Optional.of(mockTeam));
+
+        given(mockExpenseRepository.findByTeamAndStatus(mockTeam, status)).willReturn(expenses);
         given(mockItemRepository.findAllByExpenseId(expense.getId())).willReturn(items);
         given(mockPersonalExpenseRepository.countByMemberIdAndItemIds(memberId,
             items.stream().map(Item::getId).toList())).willReturn(1L);


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- expenseService 로직 중 JPQL에 검증되지 않은 id로 데이터에 접근하는 부분에 `findById`를 추가했습니다
- 이에 대한 테스트 코드도 수정했습니다.
- 추가로 `ExpenseServiceTest` 코드에서 `mockRepository`들의 변수명에서 `mock`을 삭제했습니다
  - IntelliJ에서 제공해주는 자동완성 기능을 편하게 사용하기 위해 수정했습니다.

### 🔍 참고 사항
- 참고해야 할 사항이 있다면 작성

### ⚠️ 의논 필요
- 팀원들의 의견을 듣고 싶거나, 의논이 필요한 사항이 있다면 작성

### 🐞현재 버그
- 현재 버전에 버그가 있다면 작성

### #️⃣ 연관 이슈(Git Close)
close #122 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
