### PR TITLE
Feature/issue#128: Swagger에서 같은 코드의 여러 에러 응답을 볼 수 있도록 수정

### DIFF
--- a/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
@@ -6,12 +6,13 @@ import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kappzzang.jeongsan.dto.request.CompleteExpensesRequest;
 import kappzzang.jeongsan.dto.request.SavePersonalExpenseRequest;
 import kappzzang.jeongsan.dto.response.ExpenseResponse;
+import kappzzang.jeongsan.global.common.ApiErrorTypeExample;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
+import kappzzang.jeongsan.global.common.enumeration.ErrorType;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "지출 목록 관리", description = "지출 내역에 대한 조회, 저장 등 관리하는 API")
@@ -23,13 +24,9 @@ public interface ExpenseControllerInterface {
         @Parameter(name = "state", description = "지출 내역의 상태를 지정하는 쿼리 파라미터(`ongoing`, `pending`, `completed`)"),
         @Parameter(name = "isChecked", description = "`정산 중`상태의 지출 목록 중 사용자의 현재 선택한 상태를 지정하는 쿼리 파라미터")
     })
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "지출 내역 목록을 성공적으로 조회",
-            content = @Content(schema = @Schema(implementation = ExpenseResponse.class))),
-        @ApiResponse(responseCode = "400", description = "누락된 쿼리 파라미터가 존재 (ErrorCode=E400002)"),
-        @ApiResponse(responseCode = "400", description = "`state`에 잘못된 값 입력. `ongoing`, `pending`, `completed`만 가능 (ErrorCode-E400003)"),
-        @ApiResponse(responseCode = "404", description = "`teamId`에 해당하는 모임이 존재하지 않음. (ErrorCode-E404002)")
-    })
+    @ApiResponse(responseCode = "200", description = "지출 내역 목록을 성공적으로 조회", content = @Content(schema = @Schema(implementation = ExpenseResponse.class)))
+    @ApiErrorTypeExample({ErrorType.EXPENSE_MISSING_PARAM, ErrorType.EXPENSE_INVALID_STATE,
+        ErrorType.TEAM_NOT_FOUND})
     ResponseEntity<JeongsanApiResponse<ExpenseResponse>> getAllExpenses(Long memberId, Long teamId,
         String state, Boolean isChecked);
 
@@ -37,15 +34,10 @@ public interface ExpenseControllerInterface {
     @Parameters({
         @Parameter(name = "teamId", description = "상태 변경될 지출들의 모임 ID"),
     })
-    @ApiResponses({
-        @ApiResponse(responseCode = "204", description = "지출 상태 변경을 성공"),
-        @ApiResponse(responseCode = "400", description =
-            "이미 정산 완료된 지출 존재 (ErrorCode=E400007), "
-                + "아직 진행중인 상태의 지출 존재 (ErrorCode=E400008), "
-                + "요청 목록에 존재하지 않는 지출 포함 (ErrorCode=E400009), "
-                + "요청 목록에 타 모임의 지출이 포함(ErrorCode=E400010), "
-                + "요청 목록에 본인이 결제하지 않은 지출이 포함(ErrorCode=E400011)"),
-    })
+    @ApiResponse(responseCode = "204", description = "지출 상태 변경을 성공")
+    @ApiErrorTypeExample({ErrorType.EXPENSE_ALREADY_COMPLETED, ErrorType.EXPENSE_ONGOING,
+        ErrorType.EXPENSE_NOT_FOUND_ID, ErrorType.EXPENSE_INVALID_TEAM,
+        ErrorType.EXPENSE_INVALID_PAYER})
     ResponseEntity<JeongsanApiResponse<Void>> changeExpensesStatusComplete(
         CompleteExpensesRequest request, Long teamId, Long memberId);
 
@@ -54,17 +46,10 @@ public interface ExpenseControllerInterface {
         @Parameter(name = "teamId", description = "요청 멤버가 속한 모임의 ID"),
         @Parameter(name = "expenseId", description = "선택한 아이템이 속한 지출의 ID"),
     })
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "개인 소비 내역 저장 성공", content = @Content),
-        @ApiResponse(responseCode = "400", description =
-            "이전에 선택하여 저장 한 아이템이 포함된 요청 (ErrorCode-E400013), "
-                + "아이템 quantity 보다 많은 선택 수량 (ErrorCode=E400012)", content = @Content),
-        @ApiResponse(responseCode = "404", description =
-            "`teamId` 에 해당하는 데이터가 존재하지 않음 (ErrorCode-E404002), "
-                + "`expenseId` 에 해당하는 데이터가 존재하지 않음 (ErrorCode-E404004), "
-                + "`itemId` 에 해당하는 데이터가 존재하지 않음 (ErrorCode-E404007), "
-                + " 요청 멤버가 팀의 멤버가 아님 (ErrorCode-E404008), ", content = @Content)
-    })
+    @ApiResponse(responseCode = "200", description = "개인 소비 내역 저장 성공", content = @Content)
+    @ApiErrorTypeExample({ErrorType.INVALID_QUANTITY, ErrorType.ALREADY_CHECKED_ITEM,
+        ErrorType.TEAM_NOT_FOUND, ErrorType.EXPENSE_NOT_FOUND, ErrorType.ITEM_NOT_FOUND,
+        ErrorType.TEAM_MEMBER_NOT_FOUND})
     ResponseEntity<JeongsanApiResponse<Void>> savePersonalExpense(Long teamId,
         Long expenseId, Long memberId, SavePersonalExpenseRequest personalExpense);
 

--- a/src/main/java/kappzzang/jeongsan/controller/docs/MemberControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/MemberControllerInterface.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kappzzang.jeongsan.dto.request.JoinTeamRequest;
 import kappzzang.jeongsan.dto.request.LoginRequest;
@@ -13,7 +12,9 @@ import kappzzang.jeongsan.dto.request.RegisterRequest;
 import kappzzang.jeongsan.dto.response.GetPayLinkResponse;
 import kappzzang.jeongsan.dto.response.LoginResponse;
 import kappzzang.jeongsan.dto.response.RefreshResponse;
+import kappzzang.jeongsan.global.common.ApiErrorTypeExample;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
+import kappzzang.jeongsan.global.common.enumeration.ErrorType;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "회원 관리", description = "JWT 반환, 멤버 그룹 참여, 초대 현황 등을 관리하는 API")
@@ -23,8 +24,8 @@ public interface MemberControllerInterface {
     @Parameters({
         @Parameter(name = "email", description = "카카오 회원 정보의 이메일")
     })
-    @ApiResponses({@ApiResponse(responseCode = "200", description = "로그인 성공"),
-        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음. (ErrorCode-E404001")})
+    @ApiResponse(responseCode = "200", description = "로그인 성공")
+    @ApiErrorTypeExample(ErrorType.USER_NOT_FOUND)
     ResponseEntity<JeongsanApiResponse<LoginResponse>> login(LoginRequest loginRequest);
 
     @Operation(summary = "회원가입 API", description = "카카오 로그인으로 회원가입 후 토큰을 받는 API")
@@ -33,30 +34,27 @@ public interface MemberControllerInterface {
         @Parameter(name = "email", description = "카카오 회원 정보의 이메일"),
         @Parameter(name = "profileImage", description = "카카오 회원 정보의 프로필 URL")
     })
-    @ApiResponses({@ApiResponse(responseCode = "201", description = "회원가입 성공"),
-        @ApiResponse(responseCode = "400", description = "해당 사용자는 이미 회원가입됨. (ErrorCode-E400007")})
+    @ApiResponse(responseCode = "201", description = "회원가입 성공")
+    @ApiErrorTypeExample(ErrorType.USER_ALREADY_EXISTED)
     ResponseEntity<JeongsanApiResponse<LoginResponse>> register(RegisterRequest registerRequest);
 
     @Operation(summary = "액세스 토큰 재발급 API", description = "리프레시 토큰으로 액세스 토큰을 받는 API")
     @Parameters({
         @Parameter(name = "refreshToken", description = "서비스 서버 리프레시 토큰")
     })
-    @ApiResponses({@ApiResponse(responseCode = "200", description = "액세스 토큰 재발급 성공"),
-        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음. (ErrorCode-E404001)"),
-        @ApiResponse(responseCode = "403", description = "리프레시 토큰이 유효하지 않음. (ErrorCode-E403001)")})
+    @ApiResponse(responseCode = "200", description = "액세스 토큰 재발급 성공")
+    @ApiErrorTypeExample({ErrorType.USER_NOT_FOUND, ErrorType.REFRESH_TOKEN_INVALID})
     ResponseEntity<JeongsanApiResponse<RefreshResponse>> refresh(Long memberId,
         RefreshRequest refreshRequest);
 
     @Operation(summary = "모임 초대 수락 API", description = "모임 초대 링크를 받은 사용자가 모임 참여를 수락하여 모임에 참여하도록 하는 API")
-    @ApiResponses({@ApiResponse(responseCode = "204", description = "모임 초대 수락, 모임 참여 성공"),
-        @ApiResponse(responseCode = "400", description = "모임에 초대 되지 않은 멤버. (ErrorCode-E400002"),
-        @ApiResponse(responseCode = "400", description = "이미 모임에 참여중인 멤버. (ErrorCode-E400003)"),
-        @ApiResponse(responseCode = "404", description = "잘못된 memberId, 사용자를 찾을 수 없음. (ErrorCode-E404001)"),
-        @ApiResponse(responseCode = "404", description = "잘못된 teamId, 모임을 찾을 수 없음. (ErrorCode-E404002)")})
+    @ApiResponse(responseCode = "204", description = "모임 초대 수락, 모임 참여 성공")
+    @ApiErrorTypeExample({ErrorType.NOT_INVITED_MEMBER, ErrorType.ALREADY_JOINED_MEMBER,
+        ErrorType.USER_NOT_FOUND, ErrorType.TEAM_NOT_FOUND})
     ResponseEntity<JeongsanApiResponse<Void>> joinTeam(Long teamId, JoinTeamRequest request);
 
     @Operation(summary = "송금 링크 조회 API", description = "카카오페이 송금 링크를 조회하는 API")
-    @ApiResponses({@ApiResponse(responseCode = "200", description = "카카오 페이 송금 링크 조회 성공"),
-        @ApiResponse(responseCode = "404", description = "카카오 페이 송금 링크를 찾을 수 없음. (ErrorCode-E404006)")})
+    @ApiResponse(responseCode = "200", description = "카카오 페이 송금 링크 조회 성공")
+    @ApiErrorTypeExample(ErrorType.KAKAO_PAY_LINK_NOT_FOUND)
     ResponseEntity<JeongsanApiResponse<GetPayLinkResponse>> getPayLink(Long memberId);
 }

--- a/src/main/java/kappzzang/jeongsan/controller/docs/ReceiptControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/ReceiptControllerInterface.java
@@ -5,55 +5,41 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kappzzang.jeongsan.dto.Image;
 import kappzzang.jeongsan.dto.request.SaveExpenseRequest;
 import kappzzang.jeongsan.dto.response.ParsedReceiptResponse;
 import kappzzang.jeongsan.dto.response.PersonalExpenseDetailResponse;
 import kappzzang.jeongsan.dto.response.SaveExpenseResponse;
+import kappzzang.jeongsan.global.common.ApiErrorTypeExample;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
+import kappzzang.jeongsan.global.common.enumeration.ErrorType;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "영수증 관리", description = "영수증 분석, 등록, 조회 등을 관리하는 API")
 public interface ReceiptControllerInterface {
 
     @Operation(summary = "영수증 내역 분석&조회 API", description = "영수증 분석 요청을 처리하는 API")
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "영수증 분석 결과 조회 성공",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ParsedReceiptResponse.class))),
-        @ApiResponse(responseCode = "400", description = "유효하지 않은 입력 값 (ErrorCode-E400)", content = @Content),
-        @ApiResponse(responseCode = "408", description = "요청 시간 초과 (ErrorCode-E408001)", content = @Content),
-        @ApiResponse(responseCode = "500", description = "서버 내부 오류 (ErrorCode-E500001), 영수증 데이터 추출 실패 (ErrorCode-E500002), 외부 API 호출 실패 (ErrorCode-E500003)",
-            content = @Content),
-    })
+    @ApiResponse(responseCode = "200", description = "영수증 분석 결과 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ParsedReceiptResponse.class)))
+    @ApiErrorTypeExample({ErrorType.INVALID_INPUT, ErrorType.EXTERNAL_API_REQUEST_TIMEOUT, ErrorType.INTERNAL_SERVER_ERROR})
     ResponseEntity<JeongsanApiResponse<ParsedReceiptResponse>> analyzeReceipt(Image image);
 
     @Operation(summary = "영수증 내역 분석&조회 API 테스트", description = "영수증 분석 요청 테스트용 API")
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "영수증 분석 결과 조회 성공"),
-        @ApiResponse(responseCode = "400", description = "유효하지 않은 입력 값 (ErrorCode-E400)", content = @Content),
-    })
+    @ApiResponse(responseCode = "200", description = "영수증 분석 결과 조회 성공")
+    @ApiErrorTypeExample(ErrorType.INVALID_INPUT)
     ResponseEntity<JeongsanApiResponse<Void>> mockAnalyzeReceipt(Image image);
 
     @Operation(summary = "지출 내역 저장", description = "영수증 수기 입력 또는 분석 내역 조회 후 수정 값을 저장하는 API")
     @Parameter(name = "teamId", description = "해당 지출이 저장될 teamId")
-    @ApiResponses({
-        @ApiResponse(responseCode = "201", description = "지출 내역 저장 완료", content = @Content(mediaType = "application/json", schema = @Schema(implementation = SaveExpenseResponse.class))),
-        @ApiResponse(responseCode = "400", description = "유효하지 않은 입력 값 (ErrorCode-E400006)", content = @Content),
-        @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자 (ErrorCode-E404001), 존재하지 않는 모임 (ErrorCode-E404002), 존재하지 않는 카테고리 (ErrorCode-E404)", content = @Content),
-        @ApiResponse(responseCode = "500", description = "서버 내부 오류 (ErrorCode-E500001), 외부 API 호출 실패 (ErrorCode-E500003)", content = @Content)
-    })
+    @ApiResponse(responseCode = "201", description = "지출 내역 저장 완료", content = @Content(mediaType = "application/json", schema = @Schema(implementation = SaveExpenseResponse.class)))
+    @ApiErrorTypeExample({ErrorType.INVALID_INPUT, ErrorType.USER_NOT_FOUND, ErrorType.INTERNAL_SERVER_ERROR})
     ResponseEntity<JeongsanApiResponse<SaveExpenseResponse>> addExpense(
         SaveExpenseRequest request, Long teamId, Long memberId);
 
     @Operation(summary = "지출 상세 내역 조회", description = "지출 내역 상세를 조회하는 API")
     @Parameter(name = "expenseId", description = "조회할 지출 ID")
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "지출 상세 내역 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PersonalExpenseDetailResponse.class))),
-        @ApiResponse(responseCode = "404", description = "존재하지 않는 지출 (ErrorCode-E404004)", content = @Content),
-        @ApiResponse(responseCode = "500", description = "서버 내부 오류 (ErrorCode-E500001), 외부 서버 호출 오류(ErrorCode-E500003)(영수증 이미지 로딩 실패)", content = @Content)
-    })
+    @ApiResponse(responseCode = "200", description = "지출 상세 내역 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PersonalExpenseDetailResponse.class)))
+    @ApiErrorTypeExample({ErrorType.EXPENSE_NOT_FOUND, ErrorType.INTERNAL_SERVER_ERROR})
     ResponseEntity<JeongsanApiResponse<PersonalExpenseDetailResponse>> getPersonalExpenseDetails(
         Long memberId, Long expenseId);
 }

--- a/src/main/java/kappzzang/jeongsan/controller/docs/TeamControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/TeamControllerInterface.java
@@ -6,14 +6,15 @@ import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import kappzzang.jeongsan.dto.request.CreateTeamRequest;
 import kappzzang.jeongsan.dto.response.CreateTeamResponse;
 import kappzzang.jeongsan.dto.response.InvitationStatusResponse;
 import kappzzang.jeongsan.dto.response.TeamResponse;
+import kappzzang.jeongsan.global.common.ApiErrorTypeExample;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
+import kappzzang.jeongsan.global.common.enumeration.ErrorType;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "모임 관리", description = "모임 생성, 종료, 목록 조회, 멤버 초대 현황 등을 관리하는 API")
@@ -21,10 +22,7 @@ public interface TeamControllerInterface {
 
     @Operation(summary = "모임 목록 조회 API", description = "모임 목록을 조회하는 API")
     @Parameter(name = "isClosed", description = "모임의 현재 상태(진행 중, 종료)")
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "모임 목록 조회 성공",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = TeamResponse.class))),
-    })
+    @ApiResponse(responseCode = "200", description = "모임 목록 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = TeamResponse.class)))
     ResponseEntity<JeongsanApiResponse<List<TeamResponse>>> getTeams(Boolean isClosed);
 
     @Operation(summary = "모임 생성 API", description = "요청한 사용자가 주인으로 모임을 생성하는 API")
@@ -33,11 +31,8 @@ public interface TeamControllerInterface {
         @Parameter(name = "subject", description = "모임의 목적. 이모지 사용"),
         @Parameter(name = "members", description = "모임에 초대할 사용자들 ID")
     })
-    @ApiResponses({
-        @ApiResponse(responseCode = "201", description = "모임 생성 성공"),
-        @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음(ErrorCode-E404001)"),
-        @ApiResponse(responseCode = "409", description = "중복된 모임 이름이 존재함(ErrorCode-E409001)")
-    })
+    @ApiResponse(responseCode = "201", description = "모임 생성 성공")
+    @ApiErrorTypeExample({ErrorType.USER_NOT_FOUND, ErrorType.TEAM_NAME_DUPLICATED})
     ResponseEntity<JeongsanApiResponse<CreateTeamResponse>> createTeam(Long memberId,
         CreateTeamRequest request);
 
@@ -45,22 +40,14 @@ public interface TeamControllerInterface {
     @Parameters({
         @Parameter(name = "teamId", description = "종료를 원하는 모임의 id")
     })
-    @ApiResponses({
-        @ApiResponse(responseCode = "204", description = "모임을 `종료` 상태로 변경",
-            content = @Content),
-        @ApiResponse(responseCode = "400", description = "모임이 이미 종료된 상태 (ErrorCode-E400001)"),
-        @ApiResponse(responseCode = "404", description = "`teamId`에 해당하는 모임을 찾을 수 없음 (ErrorCode-E404002)")
-    })
+    @ApiResponse(responseCode = "204", description = "모임을 `종료` 상태로 변경", content = @Content)
+    @ApiErrorTypeExample({ErrorType.TEAM_ALREADY_CLOSED, ErrorType.TEAM_NOT_FOUND})
     ResponseEntity<JeongsanApiResponse<Void>> closeTeam(Long teamId);
 
     @Operation(summary = "모임 멤버 초대 현황 조회 API", description = "모임에 초대한 멤버들의 초대 수락/대기 상태를 조회하는 API")
     @Parameter(name = "teamId", description = "멤버 초대 현황을 조회하려는 모임의 id")
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "모임의 멤버 초대 현황 조회 성공",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = InvitationStatusResponse.class))),
-        @ApiResponse(responseCode = "404", description = "`teamId`에 해당하는 모임을 찾을 수 없음 (ErrorCode-E404002)"),
-        @ApiResponse(responseCode = "404", description = "모임의 멤버 초대 현황 목록을 찾을 수 없음 (ErrorCode-E404005)")
-    })
+    @ApiResponse(responseCode = "200", description = "모임의 멤버 초대 현황 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = InvitationStatusResponse.class)))
+    @ApiErrorTypeExample({ErrorType.TEAM_NOT_FOUND, ErrorType.INVITATION_STATUS_NOT_FOUND})
     ResponseEntity<JeongsanApiResponse<List<InvitationStatusResponse>>> getInvitationStatus(
         Long teamId);
 }

--- a/src/main/java/kappzzang/jeongsan/global/common/ApiErrorTypeExample.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/ApiErrorTypeExample.java
@@ -10,5 +10,5 @@ import kappzzang.jeongsan.global.common.enumeration.ErrorType;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiErrorTypeExample {
 
-    Class<? extends ErrorType> value();
+    ErrorType[] value();
 }

--- a/src/main/java/kappzzang/jeongsan/global/common/ApiErrorTypeExample.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/ApiErrorTypeExample.java
@@ -1,0 +1,14 @@
+package kappzzang.jeongsan.global.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import kappzzang.jeongsan.global.common.enumeration.ErrorType;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorTypeExample {
+
+    Class<? extends ErrorType> value();
+}

--- a/src/main/java/kappzzang/jeongsan/global/config/SwaggerConfig.java
+++ b/src/main/java/kappzzang/jeongsan/global/config/SwaggerConfig.java
@@ -96,9 +96,8 @@ public class SwaggerConfig {
     }
 
     private void createErrorTypeExampleResponse(Operation operation,
-        Class<? extends ErrorType> type) {
+        ErrorType[] errorTypes) {
         ApiResponses responses = operation.getResponses();
-        ErrorType[] errorTypes = type.getEnumConstants();
 
         Map<Integer, List<ExampleHolder>> statusWithExampleHolders =
             Arrays.stream(errorTypes)

--- a/src/main/java/kappzzang/jeongsan/global/config/SwaggerConfig.java
+++ b/src/main/java/kappzzang/jeongsan/global/config/SwaggerConfig.java
@@ -1,12 +1,27 @@
 package kappzzang.jeongsan.global.config;
 
+import static java.util.stream.Collectors.groupingBy;
+
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import kappzzang.jeongsan.global.common.enumeration.ErrorType;
+import kappzzang.jeongsan.global.common.ApiErrorTypeExample;
+import kappzzang.jeongsan.global.swagger.ErrorResponse;
+import kappzzang.jeongsan.global.swagger.ExampleHolder;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,7 +37,6 @@ public class SwaggerConfig {
 
     @Value("${url.test}")
     private String testUrl;
-
 
     @Bean
     public OpenAPI openAPI() {
@@ -67,5 +81,57 @@ public class SwaggerConfig {
         test.setDescription("Weekly 브랜치 배포");
 
         return List.of(local, deploy, test);
+    }
+
+    @Bean
+    public OperationCustomizer customize() {
+        return (operation, handlerMethod) -> {
+            ApiErrorTypeExample apiErrorTypeExample = handlerMethod.getMethodAnnotation(
+                ApiErrorTypeExample.class);
+            if (apiErrorTypeExample != null) {
+                createErrorTypeExampleResponse(operation, apiErrorTypeExample.value());
+            }
+            return operation;
+        };
+    }
+
+    private void createErrorTypeExampleResponse(Operation operation,
+        Class<? extends ErrorType> type) {
+        ApiResponses responses = operation.getResponses();
+        ErrorType[] errorTypes = type.getEnumConstants();
+
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders =
+            Arrays.stream(errorTypes)
+                .map(errorType -> ExampleHolder.builder()
+                    .statusCode(errorType.getHttpStatusCode().value())
+                    .holder(getSwaggerExample(errorType))
+                    .errorCode(errorType.getErrorCode())
+                    .build())
+                .collect(groupingBy(ExampleHolder::getStatusCode));
+
+        addExamplesToResponses(responses, statusWithExampleHolders);
+    }
+
+    private Example getSwaggerExample(ErrorType errorType) {
+        ErrorResponse errorResponse = new ErrorResponse("failure", errorType.getErrorCode(),
+            errorType.getMessage());
+        Example example = new Example();
+        example.setValue(errorResponse);
+        return example;
+    }
+
+    private void addExamplesToResponses(ApiResponses responses,
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+        statusWithExampleHolders.forEach((status, examples) -> {
+            Content content = new Content();
+            MediaType mediaType = new MediaType();
+            ApiResponse apiResponse = new ApiResponse();
+
+            examples.forEach(exampleHolder -> mediaType.addExamples(exampleHolder.getErrorCode(),
+                exampleHolder.getHolder()));
+            content.addMediaType("application/json", mediaType);
+            apiResponse.setContent(content);
+            responses.addApiResponse(status.toString(), apiResponse);
+        });
     }
 }

--- a/src/main/java/kappzzang/jeongsan/global/swagger/ErrorResponse.java
+++ b/src/main/java/kappzzang/jeongsan/global/swagger/ErrorResponse.java
@@ -1,0 +1,13 @@
+package kappzzang.jeongsan.global.swagger;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+
+    private String status;
+    private String errorCode;
+    private String message;
+}

--- a/src/main/java/kappzzang/jeongsan/global/swagger/ExampleHolder.java
+++ b/src/main/java/kappzzang/jeongsan/global/swagger/ExampleHolder.java
@@ -1,0 +1,14 @@
+package kappzzang.jeongsan.global.swagger;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExampleHolder {
+
+    private Integer statusCode;
+    private Example holder;
+    private String errorCode;
+}


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 여러 에러 응답을 드롭다운 형식으로 구현
- 커스텀 어노테이션 추가
- 기존 docs 리팩토링

### 🔍 참고 사항
- ErrorType을 도메인 별로 나누기보단 어노테이션에 직접 기입하여 사용하는 식으로 구현하였습니다.
    ```
    @Operation(summary = "지출 상태 변경(송금 대기 -> 완료) 요청 API", description = "송금 메시지를 전송한 지출의 상태를 완료로 변경하는 API")
    @Parameters({
        @Parameter(name = "teamId", description = "상태 변경될 지출들의 모임 ID"),
    })
    @ApiResponse(responseCode = "204", description = "지출 상태 변경을 성공")
    @ApiErrorTypeExample({
        ErrorType.EXPENSE_ALREADY_COMPLETED, ErrorType.EXPENSE_ONGOING,
        ErrorType.EXPENSE_NOT_FOUND_ID, ErrorType.EXPENSE_INVALID_TEAM,
        ErrorType.EXPENSE_INVALID_PAYER
    })
    ResponseEntity<JeongsanApiResponse<Void>> changeExpensesStatusComplete(CompleteExpensesRequest request, Long teamId, Long memberId);

    ```
    <img src="https://github.com/user-attachments/assets/16e4ddba-7c84-495c-89f6-1a3099c36538" width="480px" height = "350px"  />


### ⚠️ 의논 필요
X

### 🐞현재 버그
X

### #️⃣ 연관 이슈(Git Close)
close #128 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
