### PR TITLE
Feature/issue#153: 모임 조회 및 지출 내역 조회 response 명세 변경

### DIFF
--- a/src/main/java/kappzzang/jeongsan/controller/ExampleController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/ExampleController.java
@@ -1,10 +1,11 @@
 package kappzzang.jeongsan.controller;
 
 import static kappzzang.jeongsan.global.common.enumeration.ErrorType.USER_NOT_FOUND;
-import static kappzzang.jeongsan.global.common.enumeration.SuccessType.TEAM_CREATED;
+import static kappzzang.jeongsan.global.common.enumeration.SuccessType.TEAM_LOADED;
 
 import io.swagger.v3.oas.annotations.Hidden;
-import kappzzang.jeongsan.domain.Team;
+import java.util.Collections;
+import kappzzang.jeongsan.dto.response.TeamResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,12 +20,15 @@ public class ExampleController {
 
     @GetMapping("/success")
     public ResponseEntity<JeongsanApiResponse<Void>> successWithNoData() {
-        return JeongsanApiResponse.success(TEAM_CREATED);
+        return JeongsanApiResponse.success(TEAM_LOADED);
     }
 
     @PostMapping("/success/data")
-    public ResponseEntity<JeongsanApiResponse<Team>> successWithData() {
-        return JeongsanApiResponse.success(TEAM_CREATED, new Team());
+    public ResponseEntity<JeongsanApiResponse<TeamResponse>> successWithData() {
+        var testData = new TeamResponse(
+            1L, "test", "test kakao id", true, "❤", Collections.emptyList()
+        );
+        return JeongsanApiResponse.success(TEAM_LOADED, testData);
     }
 
     @GetMapping("/failure")

--- a/src/main/java/kappzzang/jeongsan/domain/Team.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Team.java
@@ -3,6 +3,7 @@ package kappzzang.jeongsan.domain;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -34,8 +35,8 @@ public class Team extends BaseEntity {
     @Column(nullable = false)
     private Boolean isClosed;
 
-    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<TeamMember> teamMemberList;
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<TeamMember> teamMemberList = new ArrayList<>();
 
     public Team(String name, String subject) {
         this.name = name;

--- a/src/main/java/kappzzang/jeongsan/domain/Team.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Team.java
@@ -36,13 +36,12 @@ public class Team extends BaseEntity {
     private Boolean isClosed;
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    private List<TeamMember> teamMemberList = new ArrayList<>();
+    private final List<TeamMember> teamMemberList = new ArrayList<>();
 
     public Team(String name, String subject) {
         this.name = name;
         this.subject = subject;
         this.isClosed = false;
-        teamMemberList = new ArrayList<>();
     }
 
     public static Team createTeam(Member owner, String name, String subject, List<Member> members) {

--- a/src/main/java/kappzzang/jeongsan/domain/Team.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Team.java
@@ -79,6 +79,14 @@ public class Team extends BaseEntity {
         this.isClosed = true;
     }
 
+    public String getOwnerKakaoId() {
+        return this.teamMemberList.stream()
+            .filter(TeamMember::getIsOwner)
+            .map(teamMember -> teamMember.getMember().getKakaoId())
+            .findFirst()
+            .orElseThrow(() -> new JeongsanException(ErrorType.TEAM_NOT_FOUND));
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/kappzzang/jeongsan/domain/TeamMember.java
+++ b/src/main/java/kappzzang/jeongsan/domain/TeamMember.java
@@ -4,6 +4,7 @@ import static kappzzang.jeongsan.global.common.enumeration.ErrorType.ALREADY_JOI
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -22,7 +23,7 @@ public class TeamMember extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/kappzzang/jeongsan/dto/response/ExpenseResponse.java
+++ b/src/main/java/kappzzang/jeongsan/dto/response/ExpenseResponse.java
@@ -38,6 +38,7 @@ public record ExpenseResponse(
     public record ExpenseItem(
         Long expenseId,
         String title,
+        String payerId,
         Integer totalPrice,
         LocalDateTime createdAt,
         Status state,
@@ -50,6 +51,7 @@ public record ExpenseResponse(
             return new ExpenseItem(
                 expense.getId(),
                 expense.getTitle(),
+                expense.getPayer().getKakaoId(),
                 expense.getTotalPrice(),
                 expense.getCreatedAt(),
                 expense.getStatus(),

--- a/src/main/java/kappzzang/jeongsan/dto/response/TeamResponse.java
+++ b/src/main/java/kappzzang/jeongsan/dto/response/TeamResponse.java
@@ -7,6 +7,7 @@ import kappzzang.jeongsan.dto.MemberPreview;
 public record TeamResponse(
     Long teamId,
     String name,
+    String ownerKakaoId,
     Boolean isCompleted,
     String subject,
     List<MemberPreview> memberPreviews
@@ -18,6 +19,7 @@ public record TeamResponse(
         return new TeamResponse(
             team.getId(),
             team.getName(),
+            team.getOwnerKakaoId(),
             team.getIsClosed(),
             team.getSubject(),
             team.getTeamMemberList()

--- a/src/test/java/kappzzang/jeongsan/controller/ExampleControllerTest.java
+++ b/src/test/java/kappzzang/jeongsan/controller/ExampleControllerTest.java
@@ -2,7 +2,7 @@ package kappzzang.jeongsan.controller;
 
 import static io.restassured.RestAssured.given;
 import static kappzzang.jeongsan.global.common.enumeration.ErrorType.USER_NOT_FOUND;
-import static kappzzang.jeongsan.global.common.enumeration.SuccessType.TEAM_CREATED;
+import static kappzzang.jeongsan.global.common.enumeration.SuccessType.TEAM_LOADED;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -24,7 +24,7 @@ class ExampleControllerTest {
             .when()
             .get("/api/test/success")
             .then()
-            .statusCode(TEAM_CREATED.getHttpStatusCode().value());
+            .statusCode(TEAM_LOADED.getHttpStatusCode().value());
     }
 
 
@@ -36,7 +36,7 @@ class ExampleControllerTest {
             .when()
             .post("/api/test/success/data")
             .then()
-            .statusCode(TEAM_CREATED.getHttpStatusCode().value());
+            .statusCode(TEAM_LOADED.getHttpStatusCode().value());
     }
 
     @Test

--- a/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
@@ -191,6 +191,10 @@ public class ExpenseServiceTest {
         given(expenseRepository.findByTeamAndStatus(mockTeam, status)).willReturn(expenses);
         given(teamRepository.findById(any(Long.class))).willReturn(Optional.of(mockTeam));
 
+        given(mockPayer.getKakaoId()).willReturn("kakao uuid");
+
+        given(expense.getPayer()).willReturn(mockPayer);
+
         given(expense.getId()).willReturn(1L);
         given(expense.getTitle()).willReturn("Test Expense");
         given(expense.getTotalPrice()).willReturn(1000);
@@ -220,6 +224,10 @@ public class ExpenseServiceTest {
         Item item = mock(Item.class);
         List<Expense> expenses = Collections.singletonList(expense);
         List<Item> items = Collections.singletonList(item);
+
+        given(mockPayer.getKakaoId()).willReturn("kakao uuid");
+
+        given(expense.getPayer()).willReturn(mockPayer);
 
         given(expense.getId()).willReturn(1L);
         given(expense.getTitle()).willReturn("Test Expense");
@@ -261,6 +269,9 @@ public class ExpenseServiceTest {
         given(personalExpenseRepository.findPersonalExpenseSum(anyLong(),
             anyLong())).willReturn(3000);
 
+        given(mockPayer.getKakaoId()).willReturn("kakao uuid");
+
+        given(expense.getPayer()).willReturn(mockPayer);
         given(expense.getId()).willReturn(1L);
         given(expense.getTitle()).willReturn("Test Expense");
         given(expense.getTotalPrice()).willReturn(1000);
@@ -311,6 +322,11 @@ public class ExpenseServiceTest {
         Long teamId = 1L;
         Expense expense1 = mock(Expense.class);
         Expense expense2 = mock(Expense.class);
+
+        given(mockPayer.getKakaoId()).willReturn("kakao uuid");
+
+        given(expense1.getPayer()).willReturn(mockPayer);
+        given(expense2.getPayer()).willReturn(mockPayer);
 
         given(expense1.getId()).willReturn(1L);
         given(expense1.getTitle()).willReturn("Test Expense1");


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 모임 조회
    ```json
    {
        "teamId" : "그룹 ID",
        "name" : "그룹 명",
        "ownerKakaoId": "owner uuid",   // 추가된 필드
        "isCompleted" : "False",
        "subject" : "모임 목적",
        "memberPreviews" : [
            {
                "name" : "이름",
                "profileImage" : "프로필 URL"
            },
        ]
    }
    ```
- 지출 내역 조회
  ```json
  {
        "expenseList" : [
            {
                "expenseId" : "지출 ID",
                "title": "지출 이름",
                "payerId": "결제자 UUID",  // 추가된 필드
                "totalPrice": "총 지출액",
                "createdAt": "생성 날짜",
                "state": "정산 상태",
                "category": {
                    "name": "카테고리",
                    "color": "색상코드(6자리)"
                },
            },
        ],
        "totalPrice" : "그룹 총 지출"
    }
    ```
- 테스트 컨트롤러 일부 변경

### 🔍 참고 사항
-  테스트 컨트롤러 변경 사항에 대하여
  - `new Team()`으로 모임 도메인 생성 시 Team 도메인 내부 메서드로 owner를 확인하기 위해 빈 리스트를 탐색하는 문제로 NPE 발생. 그래서 좀 더 직관적인 컨트롤러 테스트를 위해 TeamResponse를 반환하도록 수정했습니다.

### ⚠️ 의논 필요
- 팀원들의 의견을 듣고 싶거나, 의논이 필요한 사항이 있다면 작성

### 🐞현재 버그
- 현재 버전에 버그가 있다면 작성

### #️⃣ 연관 이슈(Git Close)
close #153 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
