### PR TITLE
Fix/issue#157: 명세와 다른 request 수정, 서비스 id 반환 수정

### DIFF
--- a/src/main/java/kappzzang/jeongsan/controller/MemberController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/MemberController.java
@@ -4,7 +4,6 @@ import static kappzzang.jeongsan.global.common.enumeration.SuccessType.JOIN_SUCC
 
 import jakarta.validation.Valid;
 import kappzzang.jeongsan.controller.docs.MemberControllerInterface;
-import kappzzang.jeongsan.dto.request.JoinTeamRequest;
 import kappzzang.jeongsan.dto.request.LoginRequest;
 import kappzzang.jeongsan.dto.request.RefreshRequest;
 import kappzzang.jeongsan.dto.request.RegisterRequest;
@@ -58,8 +57,8 @@ public class MemberController implements MemberControllerInterface {
     @Override
     @PostMapping("/join/{teamId}")
     public ResponseEntity<JeongsanApiResponse<Void>> joinTeam(@PathVariable("teamId") Long teamId,
-        @RequestBody JoinTeamRequest request) {
-        memberService.acceptInvite(teamId, request.memberId());
+        @AuthenticationPrincipal Long memberId) {
+        memberService.acceptInvite(teamId, memberId);
         return JeongsanApiResponse.success(JOIN_SUCCESS);
     }
 

--- a/src/main/java/kappzzang/jeongsan/controller/docs/MemberControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/MemberControllerInterface.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import kappzzang.jeongsan.dto.request.JoinTeamRequest;
 import kappzzang.jeongsan.dto.request.LoginRequest;
 import kappzzang.jeongsan.dto.request.RefreshRequest;
 import kappzzang.jeongsan.dto.request.RegisterRequest;
@@ -51,7 +50,7 @@ public interface MemberControllerInterface {
     @ApiResponse(responseCode = "204", description = "모임 초대 수락, 모임 참여 성공")
     @ApiErrorTypeExample({ErrorType.NOT_INVITED_MEMBER, ErrorType.ALREADY_JOINED_MEMBER,
         ErrorType.USER_NOT_FOUND, ErrorType.TEAM_NOT_FOUND})
-    ResponseEntity<JeongsanApiResponse<Void>> joinTeam(Long teamId, JoinTeamRequest request);
+    ResponseEntity<JeongsanApiResponse<Void>> joinTeam(Long teamId, Long memberId);
 
     @Operation(summary = "송금 링크 조회 API", description = "카카오페이 송금 링크를 조회하는 API")
     @ApiResponse(responseCode = "200", description = "카카오 페이 송금 링크 조회 성공")

--- a/src/main/java/kappzzang/jeongsan/dto/request/JoinTeamRequest.java
+++ b/src/main/java/kappzzang/jeongsan/dto/request/JoinTeamRequest.java
@@ -1,5 +1,0 @@
-package kappzzang.jeongsan.dto.request;
-
-public record JoinTeamRequest(Long memberId) {
-
-}

--- a/src/main/java/kappzzang/jeongsan/dto/response/InvitationStatusResponse.java
+++ b/src/main/java/kappzzang/jeongsan/dto/response/InvitationStatusResponse.java
@@ -1,6 +1,6 @@
 package kappzzang.jeongsan.dto.response;
 
-public record InvitationStatusResponse(Long memberId, String nickname, String profileImage,
+public record InvitationStatusResponse(String kakaoId, String nickname, String profileImage,
                                        Boolean isInviteAccepted) {
 
 }

--- a/src/main/java/kappzzang/jeongsan/repository/TeamMemberRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/TeamMemberRepository.java
@@ -15,7 +15,7 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     Optional<TeamMember> findTeamMemberByTeamAndMember(Team team, Member member);
 
     @Query("SELECT new kappzzang.jeongsan.dto.response.InvitationStatusResponse( " +
-        "tm.member.id, m.nickname, m.profileImage, tm.isInviteAccepted) " +
+        "tm.member.kakaoId, m.nickname, m.profileImage, tm.isInviteAccepted) " +
         "FROM TeamMember tm " +
         "JOIN tm.member m " +
         "WHERE tm.team.id = :teamId")

--- a/src/test/java/kappzzang/jeongsan/repository/TeamMemberRepositoryTest.java
+++ b/src/test/java/kappzzang/jeongsan/repository/TeamMemberRepositoryTest.java
@@ -52,13 +52,13 @@ class TeamMemberRepositoryTest {
         assertThat(result).hasSize(2);
 
         assertThat(result).anySatisfy(response -> {
-            assertThat(response.memberId()).isEqualTo(member1.getId());
+            assertThat(response.kakaoId()).isEqualTo(member1.getKakaoId());
             assertThat(response.nickname()).isEqualTo("nickname1");
             assertThat(response.isInviteAccepted()).isTrue();
         });
 
         assertThat(result).anySatisfy(response -> {
-            assertThat(response.memberId()).isEqualTo(member2.getId());
+            assertThat(response.kakaoId()).isEqualTo(member2.getKakaoId());
             assertThat(response.nickname()).isEqualTo("nickname2");
             assertThat(response.isInviteAccepted()).isFalse();
         });

--- a/src/test/java/kappzzang/jeongsan/service/TeamServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/TeamServiceTest.java
@@ -77,7 +77,7 @@ class TeamServiceTest {
         Long teamId = 1L;
         given(teamRepository.findById(teamId)).willReturn(Optional.of(new Team()));
         given(teamMemberRepository.findInvitationStatusByTeamId(teamId)).willReturn(
-            List.of(new InvitationStatusResponse(1L, "nickname", "profileImage", false))
+            List.of(new InvitationStatusResponse("kakaoId", "nickname", "profileImage", false))
         );
 
         // when


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- `/api/member/join/{teamId}` request 삭제
- `/api/teams/{teamId}/members` 카카오 서비스 id 반환하도록 수정

### 🔍 참고 사항
- 참고해야 할 사항이 있다면 작성

### ⚠️ 의논 필요
- 팀원들의 의견을 듣고 싶거나, 의논이 필요한 사항이 있다면 작성

### 🐞현재 버그
- 현재 버전에 버그가 있다면 작성

### #️⃣ 연관 이슈(Git Close)
close #157 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
