### PR TITLE
Fix/issue#162: 모임 멤버 아이디 조회 시 카카오 아이디를 응답하도록 수정

### DIFF
--- a/src/main/java/kappzzang/jeongsan/controller/TeamController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/TeamController.java
@@ -8,7 +8,7 @@ import kappzzang.jeongsan.dto.request.CreateTeamRequest;
 import kappzzang.jeongsan.dto.request.TransferTargetRequest;
 import kappzzang.jeongsan.dto.response.CreateTeamResponse;
 import kappzzang.jeongsan.dto.response.InvitationStatusResponse;
-import kappzzang.jeongsan.dto.response.MemberIdResponse;
+import kappzzang.jeongsan.dto.response.MemberKakaoIdResponse;
 import kappzzang.jeongsan.dto.response.TeamResponse;
 import kappzzang.jeongsan.dto.response.TransferTargetResponse;
 import kappzzang.jeongsan.global.common.JeongsanApiResponse;
@@ -75,10 +75,10 @@ public class TeamController implements TeamControllerInterface {
 
     @Override
     @GetMapping("/{teamId}/members/id")
-    public ResponseEntity<JeongsanApiResponse<List<MemberIdResponse>>> getMemberId(
+    public ResponseEntity<JeongsanApiResponse<List<MemberKakaoIdResponse>>> getMemberKakaoId(
         @PathVariable("teamId") Long teamId) {
-        List<MemberIdResponse> data = teamService.getMemberId(teamId);
-        return JeongsanApiResponse.success(SuccessType.MEMBER_ID_LOADED, data);
+        List<MemberKakaoIdResponse> data = teamService.getMemberKakaoId(teamId);
+        return JeongsanApiResponse.success(SuccessType.MEMBER_KAKAO_ID_LOADED, data);
     }
 
     @Override

--- a/src/main/java/kappzzang/jeongsan/controller/docs/TeamControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/TeamControllerInterface.java
@@ -14,7 +14,7 @@ import kappzzang.jeongsan.dto.request.CreateTeamRequest;
 import kappzzang.jeongsan.dto.request.TransferTargetRequest;
 import kappzzang.jeongsan.dto.response.CreateTeamResponse;
 import kappzzang.jeongsan.dto.response.InvitationStatusResponse;
-import kappzzang.jeongsan.dto.response.MemberIdResponse;
+import kappzzang.jeongsan.dto.response.MemberKakaoIdResponse;
 import kappzzang.jeongsan.dto.response.TeamResponse;
 import kappzzang.jeongsan.dto.response.TransferTargetResponse;
 import kappzzang.jeongsan.global.common.ApiErrorTypeExample;
@@ -62,11 +62,11 @@ public interface TeamControllerInterface {
     ResponseEntity<JeongsanApiResponse<List<InvitationStatusResponse>>> getInvitationStatus(
         Long teamId);
 
-    @Operation(summary = "모임 멤버 아이디 조회 API", description = "모임에 있는 멤버들의 서비스 아이디를 조회하는 API")
-    @Parameter(name = "teamId", description = "멤버 아이디를 조회하려는 모임의 id")
-    @ApiResponse(responseCode = "200", description = "모임의 멤버 아이디 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberIdResponse.class)))
+    @Operation(summary = "모임 멤버 카카오 아이디 조회 API", description = "모임에 있는 멤버들의 카카오 아이디를 조회하는 API")
+    @Parameter(name = "teamId", description = "멤버 카카오 아이디를 조회하려는 모임의 id")
+    @ApiResponse(responseCode = "200", description = "모임의 멤버 카카오 아이디 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberKakaoIdResponse.class)))
     @ApiErrorTypeExample({ErrorType.TEAM_NOT_FOUND, ErrorType.TEAM_MEMBER_NOT_FOUND})
-    ResponseEntity<JeongsanApiResponse<List<MemberIdResponse>>> getMemberId(Long teamId);
+    ResponseEntity<JeongsanApiResponse<List<MemberKakaoIdResponse>>> getMemberKakaoId(Long teamId);
 
     @Operation(summary = "송금 요청 대상 및 금액 조회 API", description = "송금을 요청할 멤버와 해당 멤버가 보내야할 금액을 조회하는 API")
     @Parameter(name = "teamId", description = "송금 요청 대상 및 금액 조회하려는 모임의 id")

--- a/src/main/java/kappzzang/jeongsan/dto/response/MemberIdResponse.java
+++ b/src/main/java/kappzzang/jeongsan/dto/response/MemberIdResponse.java
@@ -1,5 +1,0 @@
-package kappzzang.jeongsan.dto.response;
-
-public record MemberIdResponse(Long id) {
-
-}

--- a/src/main/java/kappzzang/jeongsan/dto/response/MemberKakaoIdResponse.java
+++ b/src/main/java/kappzzang/jeongsan/dto/response/MemberKakaoIdResponse.java
@@ -1,0 +1,5 @@
+package kappzzang.jeongsan.dto.response;
+
+public record MemberKakaoIdResponse(String id) {
+
+}

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/SuccessType.java
@@ -21,7 +21,7 @@ public enum SuccessType {
     TRANSFER_TARGET_LIST_LOADED(HttpStatus.OK, "송금 요청 대상과 금액 목록을 불러오는 데 성공했습니다."),
     CATEGORY_LIST_LOADED(HttpStatus.OK, "카테고리 목록을 불러오는 데 성공했습니다."),
     EXPENSE_DETAIL_LOADED(HttpStatus.OK, "지출 선택 상세를 불러오는 데 성공했습니다."),
-    MEMBER_ID_LOADED(HttpStatus.OK, "모임의 멤버 아이디를 불러오는 데 성공했습니다."),
+    MEMBER_KAKAO_ID_LOADED(HttpStatus.OK, "모임의 멤버 카카오 아이디를 불러오는 데 성공했습니다."),
 
     // 201 CREATED
     SIGNED_UP(HttpStatus.CREATED, "회원가입을 성공하였습니다."),

--- a/src/main/java/kappzzang/jeongsan/repository/TeamMemberRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/TeamMemberRepository.java
@@ -6,7 +6,7 @@ import kappzzang.jeongsan.domain.Member;
 import kappzzang.jeongsan.domain.Team;
 import kappzzang.jeongsan.domain.TeamMember;
 import kappzzang.jeongsan.dto.response.InvitationStatusResponse;
-import kappzzang.jeongsan.dto.response.MemberIdResponse;
+import kappzzang.jeongsan.dto.response.MemberKakaoIdResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -22,9 +22,9 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
         "WHERE tm.team.id = :teamId")
     List<InvitationStatusResponse> findInvitationStatusByTeamId(@Param("teamId") Long teamId);
 
-    @Query("SELECT new kappzzang.jeongsan.dto.response.MemberIdResponse(tm.member.id) " +
+    @Query("SELECT new kappzzang.jeongsan.dto.response.MemberKakaoIdResponse(tm.member.kakaoId) " +
         "FROM TeamMember tm " +
         "JOIN tm.member m " +
         "WHERE tm.team.id = :teamId")
-    List<MemberIdResponse> findMemberIdByTeamId(@Param("teamId") Long teamId);
+    List<MemberKakaoIdResponse> findMemberKakaoIdByTeamId(@Param("teamId") Long teamId);
 }

--- a/src/main/java/kappzzang/jeongsan/service/TeamService.java
+++ b/src/main/java/kappzzang/jeongsan/service/TeamService.java
@@ -12,7 +12,7 @@ import kappzzang.jeongsan.dto.request.CreateTeamRequest;
 import kappzzang.jeongsan.dto.request.TransferTargetRequest;
 import kappzzang.jeongsan.dto.response.CreateTeamResponse;
 import kappzzang.jeongsan.dto.response.InvitationStatusResponse;
-import kappzzang.jeongsan.dto.response.MemberIdResponse;
+import kappzzang.jeongsan.dto.response.MemberKakaoIdResponse;
 import kappzzang.jeongsan.dto.response.TeamResponse;
 import kappzzang.jeongsan.dto.response.TransferTargetResponse;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
@@ -83,11 +83,11 @@ public class TeamService {
     }
 
     @Transactional(readOnly = true)
-    public List<MemberIdResponse> getMemberId(Long teamId) {
+    public List<MemberKakaoIdResponse> getMemberKakaoId(Long teamId) {
         teamRepository.findById(teamId)
             .orElseThrow(() -> new JeongsanException(ErrorType.TEAM_NOT_FOUND));
 
-        return Optional.ofNullable(teamMemberRepository.findMemberIdByTeamId(teamId))
+        return Optional.ofNullable(teamMemberRepository.findMemberKakaoIdByTeamId(teamId))
             .filter(list -> !list.isEmpty())
             .orElseThrow(() -> new JeongsanException(ErrorType.TEAM_MEMBER_NOT_FOUND));
     }

--- a/src/test/java/kappzzang/jeongsan/repository/TeamMemberRepositoryTest.java
+++ b/src/test/java/kappzzang/jeongsan/repository/TeamMemberRepositoryTest.java
@@ -7,7 +7,7 @@ import kappzzang.jeongsan.domain.KakaoPayInfo;
 import kappzzang.jeongsan.domain.Member;
 import kappzzang.jeongsan.domain.Team;
 import kappzzang.jeongsan.dto.response.InvitationStatusResponse;
-import kappzzang.jeongsan.dto.response.MemberIdResponse;
+import kappzzang.jeongsan.dto.response.MemberKakaoIdResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -66,14 +66,14 @@ class TeamMemberRepositoryTest {
     }
 
     @Test
-    @DisplayName("모임 멤버 아이디 조회 - 레포지토리 테스트")
-    void findMemberIdByTeamId() {
+    @DisplayName("모임 멤버 카카오 아이디 조회 - 레포지토리 테스트")
+    void findMemberKakaoIdByTeamId() {
         // when
-        List<MemberIdResponse> result = teamMemberRepository.findMemberIdByTeamId(team.getId());
+        List<MemberKakaoIdResponse> result = teamMemberRepository.findMemberKakaoIdByTeamId(team.getId());
 
         // then
         assertThat(result).hasSize(2)
-            .map(memberIdResponse -> memberIdResponse.id())
-            .contains(member1.getId(), member2.getId());
+            .map(memberKakaoIdResponse -> memberKakaoIdResponse.id())
+            .contains(member1.getKakaoId(), member2.getKakaoId());
     }
 }

--- a/src/test/java/kappzzang/jeongsan/service/TeamServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/TeamServiceTest.java
@@ -18,7 +18,7 @@ import kappzzang.jeongsan.domain.Team;
 import kappzzang.jeongsan.dto.request.CreateTeamRequest;
 import kappzzang.jeongsan.dto.response.CreateTeamResponse;
 import kappzzang.jeongsan.dto.response.InvitationStatusResponse;
-import kappzzang.jeongsan.dto.response.MemberIdResponse;
+import kappzzang.jeongsan.dto.response.MemberKakaoIdResponse;
 import kappzzang.jeongsan.dto.response.TeamResponse;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
 import kappzzang.jeongsan.global.exception.JeongsanException;
@@ -97,42 +97,42 @@ class TeamServiceTest {
     }
 
     @Test
-    @DisplayName("teamId로 모임을 찾을 수 없어서 모임 멤버 아이디 조회 실패함")
-    void getMemberId_TeamNotFound() {
+    @DisplayName("teamId로 모임을 찾을 수 없어서 모임 멤버 카카오 아이디 조회 실패함")
+    void getMemberKakaoId_TeamNotFound() {
         // given
         given(teamRepository.findById(anyLong())).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> teamService.getMemberId(anyLong()))
+        assertThatThrownBy(() -> teamService.getMemberKakaoId(anyLong()))
             .isInstanceOf(JeongsanException.class)
             .hasFieldOrPropertyWithValue("errorType", ErrorType.TEAM_NOT_FOUND);
     }
 
     @Test
-    @DisplayName("해당 모임에 멤버가 없어서 모임 멤버 아이디 조회 실패함")
-    void getMemberId_TeamMemberNotFound() {
+    @DisplayName("해당 모임에 멤버가 없어서 모임 멤버 카카오 아이디 조회 실패함")
+    void getMemberKakaoId_TeamMemberKakaoNotFound() {
         // given
         given(teamRepository.findById(anyLong())).willReturn(Optional.of(new Team()));
-        given(teamMemberRepository.findMemberIdByTeamId(anyLong())).willReturn(
+        given(teamMemberRepository.findMemberKakaoIdByTeamId(anyLong())).willReturn(
             Collections.emptyList());
 
         // when & then
-        assertThatThrownBy(() -> teamService.getMemberId(anyLong()))
+        assertThatThrownBy(() -> teamService.getMemberKakaoId(anyLong()))
             .isInstanceOf(JeongsanException.class)
             .hasFieldOrPropertyWithValue("errorType", ErrorType.TEAM_MEMBER_NOT_FOUND);
     }
 
     // 성공
     @Test
-    @DisplayName("모임 멤버 아이디 조회 성공")
-    void getMemberId_MemberIdLoaded() {
+    @DisplayName("모임 멤버 카카오 아이디 조회 성공")
+    void getMemberKakaoId_MemberKakaoIdLoaded() {
         // given
         given(teamRepository.findById(anyLong())).willReturn(Optional.of(new Team()));
-        given(teamMemberRepository.findMemberIdByTeamId(anyLong())).willReturn(
-            List.of(new MemberIdResponse(1L)));
+        given(teamMemberRepository.findMemberKakaoIdByTeamId(anyLong())).willReturn(
+            List.of(new MemberKakaoIdResponse("kakaoId")));
 
         // when
-        List<MemberIdResponse> result = teamService.getMemberId(anyLong());
+        List<MemberKakaoIdResponse> result = teamService.getMemberKakaoId(anyLong());
 
         // then
         assertThat(result)
@@ -140,7 +140,7 @@ class TeamServiceTest {
             .hasSize(1)
             .first()
             .satisfies(response -> {
-                assertThat(response.id()).isEqualTo(1L);
+                assertThat(response.id()).isEqualTo("kakaoId");
             });
     }
 


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 모임 멤버 아이디 조회 시 카카오 아이디를 응답하도록 수정

### 🔍 참고 사항
X

### ⚠️ 의논 필요
X

### 🐞현재 버그
X

### #️⃣ 연관 이슈(Git Close)
close #162 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
