### PR TITLE
Feature/issue#145: 개인 소비 내역 수정

### DIFF
--- a/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/ExpenseControllerInterface.java
@@ -49,7 +49,7 @@ public interface ExpenseControllerInterface {
         @Parameter(name = "expenseId", description = "선택한 아이템이 속한 지출의 ID"),
     })
     @ApiResponse(responseCode = "200", description = "개인 소비 내역 저장 성공", content = @Content)
-    @ApiErrorTypeExample({ErrorType.INVALID_QUANTITY, ErrorType.ALREADY_CHECKED_ITEM,
+    @ApiErrorTypeExample({ErrorType.INVALID_QUANTITY, ErrorType.NO_CHANGES_NEEDED,
         ErrorType.TEAM_NOT_FOUND, ErrorType.EXPENSE_NOT_FOUND, ErrorType.ITEM_NOT_FOUND,
         ErrorType.TEAM_MEMBER_NOT_FOUND})
     ResponseEntity<JeongsanApiResponse<Void>> savePersonalExpense(Long teamId,

--- a/src/main/java/kappzzang/jeongsan/domain/PersonalExpense.java
+++ b/src/main/java/kappzzang/jeongsan/domain/PersonalExpense.java
@@ -46,4 +46,9 @@ public class PersonalExpense extends BaseEntity {
     public void updateTotalPrice(int newTotalPrice) {
         this.totalPrice = newTotalPrice;
     }
+
+    public void update(int newQuantity, int newTotalPrice) {
+        this.quantity = newQuantity;
+        updateTotalPrice(newTotalPrice);
+    }
 }

--- a/src/main/java/kappzzang/jeongsan/dto/CalculatedPrice.java
+++ b/src/main/java/kappzzang/jeongsan/dto/CalculatedPrice.java
@@ -1,0 +1,5 @@
+package kappzzang.jeongsan.dto;
+
+public record CalculatedPrice(int totalQuantity, int newPersonalUnitPrice, int remainder) {
+
+}

--- a/src/main/java/kappzzang/jeongsan/dto/request/SavePersonalExpenseRequest.java
+++ b/src/main/java/kappzzang/jeongsan/dto/request/SavePersonalExpenseRequest.java
@@ -3,11 +3,12 @@ package kappzzang.jeongsan.dto.request;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
 
 public record SavePersonalExpenseRequest(@NotEmpty List<ItemInfo> items) {
 
-    public record ItemInfo(@NotNull Long itemId, @Positive Integer quantity) {
+    public record ItemInfo(@NotNull Long itemId, @PositiveOrZero Integer quantity) {
 
     }
 }

--- a/src/main/java/kappzzang/jeongsan/dto/request/SavePersonalExpenseRequest.java
+++ b/src/main/java/kappzzang/jeongsan/dto/request/SavePersonalExpenseRequest.java
@@ -2,7 +2,6 @@ package kappzzang.jeongsan.dto.request;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
 

--- a/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
+++ b/src/main/java/kappzzang/jeongsan/global/common/enumeration/ErrorType.java
@@ -21,7 +21,7 @@ public enum ErrorType {
     EXPENSE_INVALID_TEAM(HttpStatus.BAD_REQUEST, "E400010", "요청 목록에 타 모임의 지출이 포함되어 있습니다."),
     EXPENSE_INVALID_PAYER(HttpStatus.BAD_REQUEST, "E400011", "요청 목록에 본인이 결제하지 않은 지출이 포함되어 있습니다."),
     INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "E400012", "잘못된 quantity 값 요청입니다."),
-    ALREADY_CHECKED_ITEM(HttpStatus.BAD_REQUEST, "E400013", "이미 선택 완료 한 품목이 포함된 요청입니다."),
+    NO_CHANGES_NEEDED(HttpStatus.BAD_REQUEST, "E400013", "기존 quantity 값과 같은 값이 포함된 요청입니다."),
     EXPENSE_NOT_IN_TEAM(HttpStatus.BAD_REQUEST, "E400014", "팀에 속하지 않은 지출에 대한 요청입니다."),
 
     // 401 UNAUTHORIZED

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -1,7 +1,10 @@
 package kappzzang.jeongsan.service;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import kappzzang.jeongsan.domain.Expense;
 import kappzzang.jeongsan.domain.Item;
@@ -27,6 +30,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PersonalExpenseService {
 
+    @PersistenceContext
+    private EntityManager entityManager;
+
     private final MemberRepository memberRepository;
     private final TeamRepository teamRepository;
     private final ExpenseRepository expenseRepository;
@@ -49,11 +55,15 @@ public class PersonalExpenseService {
                 for (ItemInfo itemInfo : request.items()) {
                     int requestQuantity = itemInfo.quantity();
                     Item item = validateAndGetItem(itemInfo);
-                    personalExpenseRepository.findByMemberAndItem(member, item)
-                        .ifPresentOrElse(
-                            personalExpense -> update(personalExpense, item, requestQuantity),
-                            () -> save(member, item, requestQuantity)
-                        );
+                    Optional<PersonalExpense> personalExpenseOpt = personalExpenseRepository.findByMemberAndItem(member, item);
+
+                    if (personalExpenseOpt.isPresent()) {
+                        update(personalExpenseOpt.get(), item, requestQuantity);
+                        entityManager.flush();
+                        entityManager.clear();
+                    } else {
+                        save(member, item, requestQuantity);
+                    }
                 }
             } finally {
                 locks.remove(expenseId);
@@ -98,7 +108,7 @@ public class PersonalExpenseService {
         if (personalExpenses.isEmpty()) {
             return;
         }
-        if (personalExpenses.size() == 1) {
+        if (personalExpenses.size() == 1 && requestQuantity != 0) {
             personalExpense.update(requestQuantity, requestQuantity * item.getUnitPrice());
             return;
         }

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -106,9 +106,8 @@ public class PersonalExpenseService {
     private void updateExistingPersonalExpenses(List<PersonalExpense> personalExpenses,
         int newPersonalUnitPrice) {
 
-        personalExpenses.forEach(pe -> {
-            pe.updateTotalPrice(newPersonalUnitPrice * pe.getQuantity());
-        });
+        personalExpenses.forEach(
+            pe -> pe.updateTotalPrice(newPersonalUnitPrice * pe.getQuantity()));
     }
 
     private void saveNewPersonalExpense(Member member, Item item, int quantity, int totalPrice) {

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -166,13 +166,11 @@ public class PersonalExpenseService {
     private CalculatedPrice calculatedPrice(List<PersonalExpense> personalExpenses, Item item,
         int requestQuantity) {
 
-        int newPersonalUnitPrice;
+        int newPersonalUnitPrice = item.getUnitPrice();
         int totalQuantity = personalExpenses.stream().mapToInt(PersonalExpense::getQuantity).sum()
             + requestQuantity;
         if (totalQuantity > item.getQuantity()) {
             newPersonalUnitPrice = item.getTotalPrice() / totalQuantity;
-        } else {
-            newPersonalUnitPrice = item.getUnitPrice();
         }
         int remainder = item.getTotalPrice() % totalQuantity;
 

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -87,24 +87,24 @@ public class PersonalExpenseService {
     }
 
     private void update(PersonalExpense personalExpense, Item item, int requestQuantity) {
-        if (requestQuantity == 0) {
-            personalExpenseRepository.delete(personalExpense);
-            return;
-        }
-
         if (requestQuantity == personalExpense.getQuantity()) {
             throw new JeongsanException(ErrorType.NO_CHANGES_NEEDED);
         }
+        if (requestQuantity == 0) {
+            personalExpenseRepository.delete(personalExpense);
+        }
 
-        List<PersonalExpense> personalExpenses = personalExpenseRepository.findAllByItem(item)
-            .stream().filter(pe -> !pe.equals(personalExpense)).toList();
+        List<PersonalExpense> personalExpenses = personalExpenseRepository.findAllByItem(item);
         if (personalExpenses.isEmpty()) {
+            return;
+        }
+        if (personalExpenses.size() == 1) {
             personalExpense.update(requestQuantity, requestQuantity * item.getUnitPrice());
             return;
         }
 
+        personalExpenses.remove(personalExpense);
         CalculatedPrice calculatedPrice = calculatedPrice(personalExpenses, item, requestQuantity);
-
         updateExistingPersonalExpenses(personalExpenses, calculatedPrice.newPersonalUnitPrice());
         personalExpense.update(requestQuantity,
             (calculatedPrice.newPersonalUnitPrice() * requestQuantity)

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -62,8 +62,11 @@ public class PersonalExpenseService {
     }
 
     private void save(Member member, Item item, int requestQuantity) {
-        List<PersonalExpense> personalExpenses = personalExpenseRepository.findAllByItem(item);
+        if (requestQuantity == 0) {
+            throw new JeongsanException(ErrorType.INVALID_QUANTITY);
+        }
 
+        List<PersonalExpense> personalExpenses = personalExpenseRepository.findAllByItem(item);
         if (personalExpenses.isEmpty()) {
             saveNewPersonalExpense(member, item, requestQuantity,
                 item.getUnitPrice() * requestQuantity);
@@ -84,6 +87,11 @@ public class PersonalExpenseService {
     }
 
     private void update(PersonalExpense personalExpense, Item item, int requestQuantity) {
+        if (requestQuantity == 0) {
+            personalExpenseRepository.delete(personalExpense);
+            return;
+        }
+
         if (requestQuantity == personalExpense.getQuantity()) {
             throw new JeongsanException(ErrorType.NO_CHANGES_NEEDED);
         }

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -100,25 +100,25 @@ public class PersonalExpenseService {
         if (requestQuantity == personalExpense.getQuantity()) {
             throw new JeongsanException(ErrorType.NO_CHANGES_NEEDED);
         }
+
         if (requestQuantity == 0) {
             personalExpenseRepository.delete(personalExpense);
+            List<PersonalExpense> personalExpenses = personalExpenseRepository.findAllByItem(item);
+            CalculatedPrice calculatedPrice = calculatedPrice(personalExpenses, item, requestQuantity);
+            updateExistingPersonalExpenses(personalExpenses, calculatedPrice.newPersonalUnitPrice());
+            return;
         }
 
         List<PersonalExpense> personalExpenses = personalExpenseRepository.findAllByItem(item);
+        personalExpenses.remove(personalExpense);
+
         if (personalExpenses.isEmpty()) {
-            return;
-        }
-        if (personalExpenses.size() == 1 && requestQuantity != 0) {
             personalExpense.update(requestQuantity, requestQuantity * item.getUnitPrice());
             return;
         }
 
-        personalExpenses.remove(personalExpense);
         CalculatedPrice calculatedPrice = calculatedPrice(personalExpenses, item, requestQuantity);
         updateExistingPersonalExpenses(personalExpenses, calculatedPrice.newPersonalUnitPrice());
-        personalExpense.update(requestQuantity,
-            (calculatedPrice.newPersonalUnitPrice() * requestQuantity)
-                + calculatedPrice.remainder());
     }
 
     private void updateExistingPersonalExpenses(List<PersonalExpense> personalExpenses,

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -8,6 +8,7 @@ import kappzzang.jeongsan.domain.Item;
 import kappzzang.jeongsan.domain.Member;
 import kappzzang.jeongsan.domain.PersonalExpense;
 import kappzzang.jeongsan.domain.Team;
+import kappzzang.jeongsan.dto.CalculatedPrice;
 import kappzzang.jeongsan.dto.request.SavePersonalExpenseRequest;
 import kappzzang.jeongsan.dto.request.SavePersonalExpenseRequest.ItemInfo;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
@@ -37,24 +38,22 @@ public class PersonalExpenseService {
 
     @Transactional
     public void savePersonalExpense(Long memberId, Long teamId, Long expenseId,
-        SavePersonalExpenseRequest personalExpense) {
+        SavePersonalExpenseRequest request) {
 
         locks.computeIfAbsent(expenseId, id -> new Object());
 
         synchronized (locks.get(expenseId)) {
             try {
-                Member member = getMemberIfTeamAndExpenseValid(memberId, teamId, expenseId);
+                Member member = validateAndGetMember(memberId, teamId, expenseId);
 
-                for (ItemInfo itemInfo : personalExpense.items()) {
-                    Item item = getItemIfItemInfoValid(itemInfo, member);
-                    List<PersonalExpense> personalExpenses = personalExpenseRepository.findAllByItem(
-                        item);
-                    if (personalExpenses.isEmpty()) {
-                        saveNewPersonalExpense(member, item, itemInfo.quantity(),
-                            item.getUnitPrice() * itemInfo.quantity());
-                    } else {
-                        updateAndSaveRecords(personalExpenses, item, itemInfo, member);
-                    }
+                for (ItemInfo itemInfo : request.items()) {
+                    int requestQuantity = itemInfo.quantity();
+                    Item item = validateAndGetItem(itemInfo);
+                    personalExpenseRepository.findByMemberAndItem(member, item)
+                        .ifPresentOrElse(
+                            personalExpense -> update(personalExpense, item, requestQuantity),
+                            () -> save(member, item, requestQuantity)
+                        );
                 }
             } finally {
                 locks.remove(expenseId);
@@ -62,7 +61,63 @@ public class PersonalExpenseService {
         }
     }
 
-    private Member getMemberIfTeamAndExpenseValid(Long memberId, Long teamId, Long expenseId) {
+    private void save(Member member, Item item, int requestQuantity) {
+        List<PersonalExpense> personalExpenses = personalExpenseRepository.findAllByItem(item);
+
+        if (personalExpenses.isEmpty()) {
+            saveNewPersonalExpense(member, item, requestQuantity,
+                item.getUnitPrice() * requestQuantity);
+        } else {
+            updateAndSaveRecords(personalExpenses, item, requestQuantity, member);
+        }
+    }
+
+    private void updateAndSaveRecords(List<PersonalExpense> personalExpenses, Item item,
+        int requestQuantity, Member member) {
+
+        CalculatedPrice calculatedPrice = calculatedPrice(personalExpenses, item, requestQuantity);
+
+        updateExistingPersonalExpenses(personalExpenses, calculatedPrice.newPersonalUnitPrice());
+        saveNewPersonalExpense(member, item, requestQuantity,
+            (calculatedPrice.newPersonalUnitPrice() * requestQuantity)
+                + calculatedPrice.remainder());
+    }
+
+    private void update(PersonalExpense personalExpense, Item item, int requestQuantity) {
+        if (requestQuantity == personalExpense.getQuantity()) {
+            throw new JeongsanException(ErrorType.NO_CHANGES_NEEDED);
+        }
+
+        List<PersonalExpense> personalExpenses = personalExpenseRepository.findAllByItem(item)
+            .stream().filter(pe -> !pe.equals(personalExpense)).toList();
+        if (personalExpenses.isEmpty()) {
+            personalExpense.update(requestQuantity, requestQuantity * item.getUnitPrice());
+            return;
+        }
+
+        CalculatedPrice calculatedPrice = calculatedPrice(personalExpenses, item, requestQuantity);
+
+        updateExistingPersonalExpenses(personalExpenses, calculatedPrice.newPersonalUnitPrice());
+        personalExpense.update(requestQuantity,
+            (calculatedPrice.newPersonalUnitPrice() * requestQuantity)
+                + calculatedPrice.remainder());
+    }
+
+    private void updateExistingPersonalExpenses(List<PersonalExpense> personalExpenses,
+        int newPersonalUnitPrice) {
+
+        personalExpenses.forEach(pe -> {
+            pe.updateTotalPrice(newPersonalUnitPrice * pe.getQuantity());
+        });
+    }
+
+    private void saveNewPersonalExpense(Member member, Item item, int quantity, int totalPrice) {
+        PersonalExpense newPersonalExpense = PersonalExpense.builder().member(member).item(item)
+            .quantity(quantity).totalPrice(totalPrice).build();
+        personalExpenseRepository.save(newPersonalExpense);
+    }
+
+    private Member validateAndGetMember(Long memberId, Long teamId, Long expenseId) {
         Team team = teamRepository.findById(teamId)
             .orElseThrow(() -> new JeongsanException(ErrorType.TEAM_NOT_FOUND));
         Expense expense = expenseRepository.findById(expenseId)
@@ -78,12 +133,9 @@ public class PersonalExpenseService {
         return member;
     }
 
-    private Item getItemIfItemInfoValid(ItemInfo itemInfo, Member member) {
+    private Item validateAndGetItem(ItemInfo itemInfo) {
         Item item = itemRepository.findById(itemInfo.itemId())
             .orElseThrow(() -> new JeongsanException(ErrorType.ITEM_NOT_FOUND));
-        personalExpenseRepository.findByMemberAndItem(member, item).ifPresent(data -> {
-            throw new JeongsanException(ErrorType.ALREADY_CHECKED_ITEM);
-        });
         checkRequestQuantityValidity(itemInfo, item);
         return item;
     }
@@ -94,37 +146,14 @@ public class PersonalExpenseService {
         }
     }
 
-    private void updateAndSaveRecords(List<PersonalExpense> personalExpenses, Item item,
-        ItemInfo itemInfo, Member member) {
+    private CalculatedPrice calculatedPrice(List<PersonalExpense> personalExpenses, Item item,
+        int requestQuantity) {
 
         int totalQuantity = personalExpenses.stream().mapToInt(PersonalExpense::getQuantity).sum()
-            + itemInfo.quantity();
-        int requestedMemberPrice = calculateRequestMemberPrice(item.getTotalPrice(), totalQuantity,
-            itemInfo.quantity());
+            + requestQuantity;
         int newPersonalUnitPrice = item.getTotalPrice() / totalQuantity;
+        int remainder = item.getTotalPrice() % totalQuantity;
 
-        updateExistingPersonalExpenses(personalExpenses, newPersonalUnitPrice);
-        saveNewPersonalExpense(member, item, itemInfo.quantity(), requestedMemberPrice);
-    }
-
-    private void updateExistingPersonalExpenses(List<PersonalExpense> personalExpenses,
-        int newPersonalUnitPrice) {
-
-        personalExpenses.forEach(personalExpense -> {
-            personalExpense.updateTotalPrice(newPersonalUnitPrice * personalExpense.getQuantity());
-        });
-    }
-
-    private void saveNewPersonalExpense(Member member, Item item, int quantity, int totalPrice) {
-        PersonalExpense newPersonalExpense = PersonalExpense.builder().member(member).item(item)
-            .quantity(quantity).totalPrice(totalPrice).build();
-        personalExpenseRepository.save(newPersonalExpense);
-    }
-
-    private int calculateRequestMemberPrice(int totalPrice, int totalQuantity,
-        int requestQuantity) {
-        int newTotalPrice = (totalPrice / totalQuantity) * requestQuantity;
-        int remainder = totalPrice % totalQuantity;
-        return newTotalPrice + remainder;
+        return new CalculatedPrice(totalQuantity, newPersonalUnitPrice, remainder);
     }
 }

--- a/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
+++ b/src/main/java/kappzzang/jeongsan/service/PersonalExpenseService.java
@@ -156,9 +156,14 @@ public class PersonalExpenseService {
     private CalculatedPrice calculatedPrice(List<PersonalExpense> personalExpenses, Item item,
         int requestQuantity) {
 
+        int newPersonalUnitPrice;
         int totalQuantity = personalExpenses.stream().mapToInt(PersonalExpense::getQuantity).sum()
             + requestQuantity;
-        int newPersonalUnitPrice = item.getTotalPrice() / totalQuantity;
+        if (totalQuantity > item.getQuantity()) {
+            newPersonalUnitPrice = item.getTotalPrice() / totalQuantity;
+        } else {
+            newPersonalUnitPrice = item.getUnitPrice();
+        }
         int remainder = item.getTotalPrice() % totalQuantity;
 
         return new CalculatedPrice(totalQuantity, newPersonalUnitPrice, remainder);

--- a/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
@@ -204,7 +204,7 @@ class PersonalExpenseServiceTest {
     }
 
     @Test
-    @DisplayName("아이탬의 수량보다 많은 수량이 포함된 요청은 예외가 발생한다.")
+    @DisplayName("아이템의 수량보다 많은 수량이 포함된 요청은 예외가 발생한다.")
     void savePersonalExpenseExceptionTest() {
 
         // given

--- a/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
@@ -118,7 +118,9 @@ class PersonalExpenseServiceTest {
     }
 
     @Test
-    @DisplayName("개인 소비 내역 저장 - 동시성 테스트")
+    @DisplayName("3명이 동시에 개인 소비 내역을 저장하면,"
+        + "차례로 처리 되도록 하고, "
+        + "마지막에 처리된 요청이 나머지 금액을 부담한다.")
     void personalExpenseSaveConcurrencyTest() throws InterruptedException {
 
         // given
@@ -180,7 +182,8 @@ class PersonalExpenseServiceTest {
     }
 
     @Test
-    @DisplayName("개인 소비 내역 업데이트 테스트")
+    @DisplayName("기존 개인 소비 내역 데이터와 다른 수량으로 요청 시 "
+        + "개인 소비 내역이 업데이트 된다.")
     void updatePersonalExpenseTest() {
 
         // given
@@ -200,7 +203,7 @@ class PersonalExpenseServiceTest {
     }
 
     @Test
-    @DisplayName("개인 소비 내역 저장 - 예외 발생 테스트")
+    @DisplayName("아이탬의 수량보다 많은 수량이 포함된 요청은 예외가 발생한다.")
     void savePersonalExpenseExceptionTest() {
 
         // given
@@ -219,7 +222,7 @@ class PersonalExpenseServiceTest {
     }
 
     @Test
-    @DisplayName("개인 소비 내역 수정 - 동일한 수량으로 요청 시 예외 발생")
+    @DisplayName("기존 개인 소비 내역 데이터와 동일한 수량이 포함된 요청은 예외가 발생한다.")
     void updatePersonalExpenseWithSameQuantityTest() {
         // given
         SavePersonalExpenseRequest request = new SavePersonalExpenseRequest(
@@ -239,7 +242,7 @@ class PersonalExpenseServiceTest {
     }
 
     @Test
-    @DisplayName("개인 소비 내역 수정과 저장 동시 요청 테스트")
+    @DisplayName("개인 소비 내역 저장, 수정 요청이 동시에 요청된다.")
     void concurrentUpdateAndSaveTest() throws InterruptedException {
         // given
         int threadCount = 2;

--- a/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
@@ -6,12 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 import kappzzang.jeongsan.domain.Expense;
 import kappzzang.jeongsan.domain.Item;
 import kappzzang.jeongsan.domain.Member;
@@ -27,9 +25,7 @@ import kappzzang.jeongsan.repository.MemberRepository;
 import kappzzang.jeongsan.repository.PersonalExpenseRepository;
 import kappzzang.jeongsan.repository.TeamMemberRepository;
 import kappzzang.jeongsan.repository.TeamRepository;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -196,7 +192,8 @@ class PersonalExpenseServiceTest {
             request);
 
         // then
-        PersonalExpense savedExpenses = personalExpenseRepository.findByMemberAndItem(member1, item2).get();
+        PersonalExpense savedExpenses = personalExpenseRepository.findByMemberAndItem(member1,
+            item2).get();
 
         assertEquals(2, savedExpenses.getQuantity());
         assertEquals(2000, savedExpenses.getTotalPrice());
@@ -235,7 +232,8 @@ class PersonalExpenseServiceTest {
                 expense.getId(), request);
         });
 
-        PersonalExpense savedExpenses = personalExpenseRepository.findByMemberAndItem(member1, item2).get();
+        PersonalExpense savedExpenses = personalExpenseRepository.findByMemberAndItem(member1,
+            item2).get();
         assertEquals(1, savedExpenses.getQuantity());
         assertEquals(1000, savedExpenses.getTotalPrice());
     }
@@ -274,27 +272,24 @@ class PersonalExpenseServiceTest {
         List<PersonalExpense> savedExpenses = personalExpenseRepository.findAllByItem(item2);
         assertEquals(2, savedExpenses.size());
 
-
         int totalQuantity = savedExpenses.stream()
             .mapToInt(PersonalExpense::getQuantity)
             .sum();
-        assertEquals(4, totalQuantity);  // member1: 2, member4: 4
+        assertEquals(4, totalQuantity);  // member1: 2, member4: 2
 
         int totalPrice = savedExpenses.stream()
             .mapToInt(PersonalExpense::getTotalPrice)
             .sum();
         assertEquals(item2.getTotalPrice(), totalPrice);  // item2의 전체 가격
 
-        Map<Long, Integer> quantityByMember = savedExpenses.stream()
-            .collect(Collectors.toMap(
-                pe -> pe.getMember().getId(),
-                PersonalExpense::getQuantity
-            ));
-        assertEquals(2, quantityByMember.get(member1.getId()));
-        assertEquals(2, quantityByMember.get(member4.getId()));
+        for (PersonalExpense personalExpense : savedExpenses) {
+            assertEquals(2, personalExpense.getQuantity());
+            assertEquals(1500, personalExpense.getTotalPrice());
+        }
     }
 
-    private void executeTestCase(TestCase testCase, CountDownLatch startLatch, CountDownLatch endLatch) {
+    private void executeTestCase(TestCase testCase, CountDownLatch startLatch,
+        CountDownLatch endLatch) {
         try {
             startLatch.await();
             personalExpenseService.savePersonalExpense(
@@ -310,5 +305,7 @@ class PersonalExpenseServiceTest {
         }
     }
 
-    private record TestCase(Long memberId, String operation, SavePersonalExpenseRequest request) {}
+    private record TestCase(Long memberId, String operation, SavePersonalExpenseRequest request) {
+
+    }
 }

--- a/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
@@ -6,10 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import kappzzang.jeongsan.domain.Expense;
 import kappzzang.jeongsan.domain.Item;
 import kappzzang.jeongsan.domain.Member;
@@ -26,7 +28,9 @@ import kappzzang.jeongsan.repository.PersonalExpenseRepository;
 import kappzzang.jeongsan.repository.TeamMemberRepository;
 import kappzzang.jeongsan.repository.TeamRepository;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -54,12 +58,12 @@ class PersonalExpenseServiceTest {
     @Autowired
     private TeamMemberRepository teamMemberRepository;
 
-    private Member member1, member2, member3;
+    private Member member1, member2, member3, member4;
     private Team team;
     private Expense expense;
     private Item item1, item2;
 
-    @BeforeAll
+    @BeforeEach
     void setup() {
         team = teamRepository.save(new Team("Test Team", "🍎"));
         member1 = memberRepository.save(
@@ -80,8 +84,14 @@ class PersonalExpenseServiceTest {
                 .email("email3@test.com")
                 .nickname("User3")
                 .build());
+        member4 = memberRepository.save(
+            Member.builder()
+                .kakaoId("kakaoId4")
+                .email("email4@test.com")
+                .nickname("User4")
+                .build());
         item1 = new Item("Test Item", 2, 1000);
-        item2 = new Item("Test Item", 1, 1000);
+        item2 = new Item("Test Item", 3, 1000);
         expense = Expense.builder()
             .title("asdf")
             .category(null)
@@ -98,9 +108,10 @@ class PersonalExpenseServiceTest {
         teamMemberRepository.save(new TeamMember(member1, team, false, true));
         teamMemberRepository.save(new TeamMember(member2, team, false, true));
         teamMemberRepository.save(new TeamMember(member3, team, false, true));
+        teamMemberRepository.save(new TeamMember(member4, team, false, true));
     }
 
-    @AfterAll
+    @AfterEach
     void cleanup() {
         personalExpenseRepository.deleteAll();
         itemRepository.deleteAll();
@@ -173,26 +184,22 @@ class PersonalExpenseServiceTest {
     }
 
     @Test
-    @DisplayName("개인 소비 내역 저장 - 기존 데이터 업데이트 테스트")
+    @DisplayName("개인 소비 내역 업데이트 테스트")
     void updatePersonalExpenseTest() {
 
         // given
         SavePersonalExpenseRequest request = new SavePersonalExpenseRequest(
-            List.of(new SavePersonalExpenseRequest.ItemInfo(item2.getId(), 1)));
+            List.of(new SavePersonalExpenseRequest.ItemInfo(item2.getId(), 2)));
 
         // when
-        personalExpenseService.savePersonalExpense(member2.getId(), team.getId(), expense.getId(),
+        personalExpenseService.savePersonalExpense(member1.getId(), team.getId(), expense.getId(),
             request);
 
         // then
-        List<PersonalExpense> savedExpenses = personalExpenseRepository.findAllByItem(item2);
-        assertEquals(2, savedExpenses.size());
+        PersonalExpense savedExpenses = personalExpenseRepository.findByMemberAndItem(member1, item2).get();
 
-        PersonalExpense personalExpense1 = savedExpenses.get(0);
-        PersonalExpense personalExpense2 = savedExpenses.get(1);
-
-        assertEquals(personalExpense1.getQuantity(), personalExpense2.getQuantity());
-        assertEquals(personalExpense1.getTotalPrice(), personalExpense2.getTotalPrice());
+        assertEquals(2, savedExpenses.getQuantity());
+        assertEquals(2000, savedExpenses.getTotalPrice());
     }
 
     @Test
@@ -213,4 +220,95 @@ class PersonalExpenseServiceTest {
         List<PersonalExpense> savedExpenses = personalExpenseRepository.findAll();
         assertEquals(1, savedExpenses.size());
     }
+
+    @Test
+    @DisplayName("개인 소비 내역 수정 - 동일한 수량으로 요청 시 예외 발생")
+    void updatePersonalExpenseWithSameQuantityTest() {
+        // given
+        SavePersonalExpenseRequest request = new SavePersonalExpenseRequest(
+            List.of(new SavePersonalExpenseRequest.ItemInfo(item2.getId(), 1))
+        );
+
+        // when, then
+        assertThrows(JeongsanException.class, () -> {
+            personalExpenseService.savePersonalExpense(member1.getId(), team.getId(),
+                expense.getId(), request);
+        });
+
+        PersonalExpense savedExpenses = personalExpenseRepository.findByMemberAndItem(member1, item2).get();
+        assertEquals(1, savedExpenses.getQuantity());
+        assertEquals(1000, savedExpenses.getTotalPrice());
+    }
+
+    @Test
+    @DisplayName("개인 소비 내역 수정과 저장 동시 요청 테스트")
+    void concurrentUpdateAndSaveTest() throws InterruptedException {
+        // given
+        int threadCount = 2;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(threadCount);
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+
+        SavePersonalExpenseRequest updateRequest = new SavePersonalExpenseRequest(
+            List.of(new SavePersonalExpenseRequest.ItemInfo(item2.getId(), 2))
+        );
+        SavePersonalExpenseRequest saveRequest = new SavePersonalExpenseRequest(
+            List.of(new SavePersonalExpenseRequest.ItemInfo(item2.getId(), 2))
+        );
+
+        List<TestCase> testCases = List.of(
+            new TestCase(member1.getId(), "수정", updateRequest),
+            new TestCase(member4.getId(), "저장", saveRequest)
+        );
+
+        // when
+        testCases.forEach(testCase ->
+            executorService.submit(() -> executeTestCase(testCase, startLatch, endLatch))
+        );
+
+        startLatch.countDown();
+        endLatch.await();
+        executorService.shutdown();
+
+        // then
+        List<PersonalExpense> savedExpenses = personalExpenseRepository.findAllByItem(item2);
+        assertEquals(2, savedExpenses.size());
+
+
+        int totalQuantity = savedExpenses.stream()
+            .mapToInt(PersonalExpense::getQuantity)
+            .sum();
+        assertEquals(4, totalQuantity);  // member1: 2, member4: 4
+
+        int totalPrice = savedExpenses.stream()
+            .mapToInt(PersonalExpense::getTotalPrice)
+            .sum();
+        assertEquals(item2.getTotalPrice(), totalPrice);  // item2의 전체 가격
+
+        Map<Long, Integer> quantityByMember = savedExpenses.stream()
+            .collect(Collectors.toMap(
+                pe -> pe.getMember().getId(),
+                PersonalExpense::getQuantity
+            ));
+        assertEquals(2, quantityByMember.get(member1.getId()));
+        assertEquals(2, quantityByMember.get(member4.getId()));
+    }
+
+    private void executeTestCase(TestCase testCase, CountDownLatch startLatch, CountDownLatch endLatch) {
+        try {
+            startLatch.await();
+            personalExpenseService.savePersonalExpense(
+                testCase.memberId(),
+                team.getId(),
+                expense.getId(),
+                testCase.request()
+            );
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            endLatch.countDown();
+        }
+    }
+
+    private record TestCase(Long memberId, String operation, SavePersonalExpenseRequest request) {}
 }

--- a/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
@@ -1,5 +1,6 @@
 package kappzzang.jeongsan.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -59,6 +60,7 @@ class PersonalExpenseServiceTest {
     private Team team;
     private Expense expense;
     private Item item1, item2;
+    private PersonalExpense member1_pe;
 
     @BeforeEach
     void setup() {
@@ -101,7 +103,7 @@ class PersonalExpenseServiceTest {
         expense = expenseRepository.save(expense);
         itemRepository.save(item1);
         itemRepository.save(item2);
-        personalExpenseRepository.save(new PersonalExpense(member1, item2, 1, 1000));
+        member1_pe = personalExpenseRepository.save(new PersonalExpense(member1, item2, 1, 1000));
         teamMemberRepository.save(new TeamMember(member1, team, false, true));
         teamMemberRepository.save(new TeamMember(member2, team, false, true));
         teamMemberRepository.save(new TeamMember(member3, team, false, true));
@@ -243,9 +245,13 @@ class PersonalExpenseServiceTest {
     }
 
     @Test
-    @DisplayName("개인 소비 내역 수정 요청 시, 요청 수량이 0이라면 기존 데이터를 삭제한다.")
+    @DisplayName("개인 소비 내역 수정 요청 시 요청 수량이 0이라면 기존 데이터를 삭제하고,"
+        + " 남은 개인 소비 내역 데이터의 totalPrice 값을 업데이트 한다.")
     void updatePersonalExpenseWithZeroQuantityTest() {
         // given
+        member1_pe.update(2, 1500);
+        personalExpenseRepository.save(new PersonalExpense(member3, item2, 2, 1500));
+
         SavePersonalExpenseRequest updateRequest = new SavePersonalExpenseRequest(
             List.of(new SavePersonalExpenseRequest.ItemInfo(item2.getId(), 0))
         );
@@ -255,9 +261,14 @@ class PersonalExpenseServiceTest {
             updateRequest);
 
         // then
-        Optional<PersonalExpense> personalExpense = personalExpenseRepository.findByMemberAndItem(
+        Optional<PersonalExpense> deletedPersonalExpense = personalExpenseRepository.findByMemberAndItem(
             member1, item2);
-        assertTrue(personalExpense.isEmpty());
+        assertTrue(deletedPersonalExpense.isEmpty());
+        Optional<PersonalExpense> updatedPersonalExpense = personalExpenseRepository.findByMemberAndItem(
+            member3, item2);
+        assertThat(updatedPersonalExpense).isNotEmpty();
+        assertThat(updatedPersonalExpense.get().getQuantity()).isEqualTo(2);
+        assertThat(updatedPersonalExpense.get().getTotalPrice()).isEqualTo(2000);
     }
 
     @Test

--- a/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/PersonalExpenseServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -239,6 +240,43 @@ class PersonalExpenseServiceTest {
             item2).get();
         assertEquals(1, savedExpenses.getQuantity());
         assertEquals(1000, savedExpenses.getTotalPrice());
+    }
+
+    @Test
+    @DisplayName("개인 소비 내역 수정 요청 시, 요청 수량이 0이라면 기존 데이터를 삭제한다.")
+    void updatePersonalExpenseWithZeroQuantityTest() {
+        // given
+        SavePersonalExpenseRequest updateRequest = new SavePersonalExpenseRequest(
+            List.of(new SavePersonalExpenseRequest.ItemInfo(item2.getId(), 0))
+        );
+
+        // when
+        personalExpenseService.savePersonalExpense(member1.getId(), team.getId(), expense.getId(),
+            updateRequest);
+
+        // then
+        Optional<PersonalExpense> personalExpense = personalExpenseRepository.findByMemberAndItem(
+            member1, item2);
+        assertTrue(personalExpense.isEmpty());
+    }
+
+    @Test
+    @DisplayName("개인 소비 내역 저장 요청 시, 요청 수량이 0이라면 예외가 발생한다.")
+    void savePersonalExpenseWithZeroQuantityTest() {
+        // given
+        SavePersonalExpenseRequest saveRequest = new SavePersonalExpenseRequest(
+            List.of(new SavePersonalExpenseRequest.ItemInfo(item1.getId(), 0))
+        );
+
+        // when, then
+        assertThrows(JeongsanException.class, () -> {
+            personalExpenseService.savePersonalExpense(member4.getId(), team.getId(),
+                expense.getId(), saveRequest);
+        });
+
+        Optional<PersonalExpense> personalExpense = personalExpenseRepository.findByMemberAndItem(
+            member4, item1);
+        assertTrue(personalExpense.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 개인 소비 내역 수정 할 수 있도록 변경

### 🔍 참고 사항
- `findByMemberAndItem` 결과
  - 있음 & 요청 수량이 기존과 같음 -> 예외 발생
  - 있음 & 요청 수량이 기존과 다름 -> 업데이트
  - 없음 -> 저장

### ⚠️ 의논 필요
- 팀원들의 의견을 듣고 싶거나, 의논이 필요한 사항이 있다면 작성

### 🐞현재 버그
- 현재 버전에 버그가 있다면 작성

### #️⃣ 연관 이슈(Git Close)
close #145 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
