### PR TITLE
Fix/issue#166: 모임 목록 조회 시 404 예외 발생 문제 해결

### DIFF
--- a/src/main/java/kappzzang/jeongsan/domain/Member.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Member.java
@@ -65,18 +65,11 @@ public class Member extends BaseEntity {
             return false;
         }
         Member member = (Member) o;
-        return Objects.equals(teamMemberList, member.teamMemberList)
-            && Objects.equals(id, member.id) && Objects.equals(kakaoId,
-            member.kakaoId) && Objects.equals(email, member.email)
-            && Objects.equals(nickname, member.nickname) && Objects.equals(
-            profileImage, member.profileImage) && Objects.equals(refreshToken,
-            member.refreshToken) && Objects.equals(kakaoPayInfo, member.kakaoPayInfo);
+        return Objects.equals(id, member.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(teamMemberList, id, kakaoId, email, nickname, profileImage,
-            refreshToken,
-            kakaoPayInfo);
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/kappzzang/jeongsan/domain/Team.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Team.java
@@ -106,13 +106,11 @@ public class Team extends BaseEntity {
             return false;
         }
         Team team = (Team) o;
-        return Objects.equals(id, team.id) && Objects.equals(name, team.name)
-            && Objects.equals(subject, team.subject) && Objects.equals(isClosed,
-            team.isClosed);
+        return Objects.equals(id, team.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, subject, isClosed);
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/kappzzang/jeongsan/domain/Team.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Team.java
@@ -79,6 +79,10 @@ public class Team extends BaseEntity {
         this.isClosed = true;
     }
 
+    public void setClosed(Boolean closed) {
+        this.isClosed = closed;
+    }
+
     public String getOwnerKakaoId() {
         return this.teamMemberList.stream()
             .filter(TeamMember::getIsOwner)
@@ -104,11 +108,11 @@ public class Team extends BaseEntity {
         Team team = (Team) o;
         return Objects.equals(id, team.id) && Objects.equals(name, team.name)
             && Objects.equals(subject, team.subject) && Objects.equals(isClosed,
-            team.isClosed) && Objects.equals(teamMemberList, team.teamMemberList);
+            team.isClosed);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, subject, isClosed, teamMemberList);
+        return Objects.hash(id, name, subject, isClosed);
     }
 }

--- a/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
@@ -2,15 +2,16 @@ package kappzzang.jeongsan.repository;
 
 import java.util.List;
 import kappzzang.jeongsan.domain.Team;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
 
+    @EntityGraph(attributePaths = {"teamMemberList.member"})
     @Query("SELECT t FROM Team t " +
-        "JOIN FETCH t.teamMemberList tm " +
-        "JOIN FETCH tm.member " +
+        "JOIN t.teamMemberList tm " +
         "WHERE tm.member.id = :memberId " +
         "AND t.isClosed = :isClosed")
     List<Team> findByIsClosed(@Param("memberId") Long memberId, Boolean isClosed);

--- a/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
@@ -14,5 +14,5 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
         "JOIN t.teamMemberList tm " +
         "WHERE tm.member.id = :memberId " +
         "AND t.isClosed = :isClosed")
-    List<Team> findByIsClosed(@Param("memberId") Long memberId, Boolean isClosed);
+    List<Team> findByIsClosed(@Param("memberId") Long memberId, @Param("isClosed") Boolean isClosed);
 }

--- a/src/test/java/kappzzang/jeongsan/repository/TeamRepositoryTest.java
+++ b/src/test/java/kappzzang/jeongsan/repository/TeamRepositoryTest.java
@@ -1,0 +1,128 @@
+package kappzzang.jeongsan.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import kappzzang.jeongsan.domain.KakaoPayInfo;
+import kappzzang.jeongsan.domain.Member;
+import kappzzang.jeongsan.domain.Team;
+import kappzzang.jeongsan.domain.TeamMember;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+@DataJpaTest
+@TestPropertySource(locations = "classpath:application-test.properties")
+@Import(TestDataUtil.class)
+class TeamRepositoryTest {
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private TestDataUtil testDataUtil;
+
+    private Member member;
+    private Team openTeam;
+    private Team closedTeam;
+
+    @BeforeEach
+    void setUp() {
+        KakaoPayInfo kakaoPayInfo = new KakaoPayInfo();
+        member = testDataUtil.createAndPersistMember("TestUser", kakaoPayInfo);
+
+        openTeam = testDataUtil.createAndPersistTeam();
+        openTeam.setClosed(false);
+        testDataUtil.createAndPersistTeamMember(member, openTeam, true, true);
+
+        closedTeam = testDataUtil.createAndPersistTeam();
+        closedTeam.setClosed(true);
+        testDataUtil.createAndPersistTeamMember(member, closedTeam, false, true);
+
+        testDataUtil.commit();
+        testDataUtil.clear();
+    }
+
+    @Test
+    @DisplayName("모임의 isClosed `true`상태인 데이터를 불러온다")
+    void testFindByIsClosed_withOpenTeam() {
+        // given
+        Boolean isClosed = false;
+
+        // when
+        List<Team> result = teamRepository.findByIsClosed(member.getId(), isClosed);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst()).isEqualTo(openTeam);
+    }
+
+    @Test
+    @DisplayName("모임의 isClosed가 `true`상태인 데이터를 불러온다")
+    void testFindByIsClosed_withClosedTeam() {
+        // given
+        Boolean isClosed = true;
+
+        // when
+        List<Team> result = teamRepository.findByIsClosed(member.getId(), isClosed);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst()).isEqualTo(closedTeam);
+    }
+
+    @Test
+    @DisplayName("멤버가 속한 팀이 없을 때 데이터를 요청하면 빈 리스트를 반환한다")
+    void testFindByIsClosed_noMatchingTeam() {
+        // given
+        Long nonExistingMemberId = -1L;
+        Boolean isClosed = false;
+
+        // when
+        List<Team> result = teamRepository.findByIsClosed(nonExistingMemberId, isClosed);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("JPQL을 이용한 요청에 대하여 지연 로딩이 정상적으로 적용되었는지 확인")
+    void testFindByIsClosed_LazyLoadingOfTeamMembersAndMembers() {
+        // given
+        Boolean isClosed = false;
+
+        // when
+        List<Team> result = teamRepository.findByIsClosed(member.getId(), isClosed);
+
+        // then
+        assertThat(result).hasSize(1);
+        Team retrievedTeam = result.getFirst();
+
+        
+        assertThat(retrievedTeam.getTeamMemberList()).isNotEmpty();
+
+        TeamMember teamMember = retrievedTeam.getTeamMemberList().getFirst();
+        assertThat(teamMember.getMember()).isEqualTo(member);
+    }
+
+    @Test
+    @DisplayName("지연로딩을 이용한 Team.getOwnerKakaoId()를 정상적으로 수행하는지 확인하는 테스트")
+    void testGetOwnerKakaoId_withLazyLoading() {
+        // given
+        Boolean isClosed = false;
+
+        // when
+        List<Team> result = teamRepository.findByIsClosed(member.getId(), isClosed);
+
+        // then
+        assertThat(result).hasSize(1);
+        Team retrievedTeam = result.getFirst();
+
+        String ownerKakaoId = retrievedTeam.getOwnerKakaoId();
+        assertThat(ownerKakaoId).isEqualTo(member.getKakaoId());
+    }
+}

--- a/src/test/java/kappzzang/jeongsan/repository/TeamRepositoryTest.java
+++ b/src/test/java/kappzzang/jeongsan/repository/TeamRepositoryTest.java
@@ -48,7 +48,7 @@ class TeamRepositoryTest {
     }
 
     @Test
-    @DisplayName("모임의 isClosed `true`상태인 데이터를 불러온다")
+    @DisplayName("모임의 isClosed `false`상태인 데이터를 불러온다")
     void testFindByIsClosed_withOpenTeam() {
         // given
         Boolean isClosed = false;

--- a/src/test/java/kappzzang/jeongsan/repository/TestDataUtil.java
+++ b/src/test/java/kappzzang/jeongsan/repository/TestDataUtil.java
@@ -106,4 +106,8 @@ public class TestDataUtil {
         entityManager.flush();
     }
 
+    public void clear() {
+        entityManager.clear();
+    }
+
 }


### PR DESCRIPTION
## PR
### 🔍 원인
- 모임 단일 조회(JPA 기능 이용)시 정상적으로 데이터를 반환
- 그러나 모임 목록 조회(JPQL 이용)시 Team.getOwnerKakaoId()로직에서 오류 발생
- Team에 연결된 엔티티인 teamMemberList를 정상적으로 로드하지 못한다고 판단하여 이를 위주로 해결

### ✨ 작업 내용
- JPQL 일부 수정
- 검증을 위해 TeamRepositoryTest 추가

### 🔍 참고사항
- Team.getOwnerKakaoId() 메서드의 경우 도메인 테스트로 분류해야 됨이 맞으나, 데이터를 직접적으로 호출 및 확인이 필요해 repository test에 작성

### ⚠️ 의논 필요
- 팀원들의 의견을 듣고 싶거나, 의논이 필요한 사항이 있다면 작성

### 🐞현재 버그
- 현재 버전에 버그가 있다면 작성

### #️⃣ 연관 이슈(Git Close)
close #166 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
