### PR TITLE
Test/issue#171: 기존 테스트 코드 리펙토링 및 Repository, Domain Test 추가

### DIFF
--- a/src/test/java/kappzzang/jeongsan/domain/ExpenseTest.java
+++ b/src/test/java/kappzzang/jeongsan/domain/ExpenseTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class ExpenseTest {
@@ -63,7 +64,7 @@ public class ExpenseTest {
         //given
         given(team.getId()).willReturn(VALID_TEAM_ID);
         given(payer.getId()).willReturn(VALID_MEMBER_ID);
-        expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.PENDING);
+        ReflectionTestUtils.setField(expense, "status", Status.PENDING);
 
         //when
         expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.ONGOING);
@@ -78,7 +79,7 @@ public class ExpenseTest {
         //given
         given(team.getId()).willReturn(VALID_TEAM_ID);
         given(payer.getId()).willReturn(VALID_MEMBER_ID);
-        expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.PENDING);
+        ReflectionTestUtils.setField(expense, "status", Status.PENDING);
 
         //when
         expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.COMPLETED);
@@ -91,9 +92,7 @@ public class ExpenseTest {
     @Test
     void changeState_PendingToPending_throwAlreadyPendingException() {
         //given
-        given(team.getId()).willReturn(VALID_TEAM_ID);
-        given(payer.getId()).willReturn(VALID_MEMBER_ID);
-        expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.PENDING);
+        ReflectionTestUtils.setField(expense, "status", Status.PENDING);
 
         //when //then
         assertThatThrownBy(
@@ -116,10 +115,7 @@ public class ExpenseTest {
     @Test
     void changeState_CompleteToComplete_throwAlreadyCompleteException() {
         //given
-        given(team.getId()).willReturn(VALID_TEAM_ID);
-        given(payer.getId()).willReturn(VALID_MEMBER_ID);
-        expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.PENDING);
-        expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.COMPLETED);
+        ReflectionTestUtils.setField(expense, "status", Status.COMPLETED);
 
         //when //then
         assertThatThrownBy(

--- a/src/test/java/kappzzang/jeongsan/domain/ExpenseTest.java
+++ b/src/test/java/kappzzang/jeongsan/domain/ExpenseTest.java
@@ -49,8 +49,10 @@ public class ExpenseTest {
         //given
         given(team.getId()).willReturn(VALID_TEAM_ID);
         given(payer.getId()).willReturn(VALID_MEMBER_ID);
+
         //when
         expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.PENDING);
+
         //then
         assertThat(expense.getStatus()).isEqualTo(Status.PENDING);
     }
@@ -62,8 +64,10 @@ public class ExpenseTest {
         given(team.getId()).willReturn(VALID_TEAM_ID);
         given(payer.getId()).willReturn(VALID_MEMBER_ID);
         expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.PENDING);
+
         //when
         expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.ONGOING);
+
         //then
         assertThat(expense.getStatus()).isEqualTo(Status.ONGOING);
     }
@@ -75,8 +79,10 @@ public class ExpenseTest {
         given(team.getId()).willReturn(VALID_TEAM_ID);
         given(payer.getId()).willReturn(VALID_MEMBER_ID);
         expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.PENDING);
+
         //when
         expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.COMPLETED);
+
         //then
         assertThat(expense.getStatus()).isEqualTo(Status.COMPLETED);
     }
@@ -88,6 +94,7 @@ public class ExpenseTest {
         given(team.getId()).willReturn(VALID_TEAM_ID);
         given(payer.getId()).willReturn(VALID_MEMBER_ID);
         expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.PENDING);
+
         //when //then
         assertThatThrownBy(
             () -> expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.PENDING))
@@ -113,6 +120,7 @@ public class ExpenseTest {
         given(payer.getId()).willReturn(VALID_MEMBER_ID);
         expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.PENDING);
         expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.COMPLETED);
+
         //when //then
         assertThatThrownBy(
             () -> expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.COMPLETED))
@@ -125,6 +133,7 @@ public class ExpenseTest {
     void changeState_NotMatchTeam_throwExpenseInvalidTeamException() {
         //given
         given(team.getId()).willReturn(VALID_TEAM_ID);
+
         //when //then
         assertThatThrownBy(
             () -> expense.changeStatus(INVALID_TEAM_ID, VALID_MEMBER_ID, Status.PENDING))
@@ -138,6 +147,7 @@ public class ExpenseTest {
         //given
         given(team.getId()).willReturn(VALID_TEAM_ID);
         given(payer.getId()).willReturn(VALID_MEMBER_ID);
+
         //when //then
         assertThatThrownBy(
             () -> expense.changeStatus(VALID_TEAM_ID, INVALID_MEMBER_ID, Status.PENDING))

--- a/src/test/java/kappzzang/jeongsan/domain/ExpenseTest.java
+++ b/src/test/java/kappzzang/jeongsan/domain/ExpenseTest.java
@@ -1,0 +1,147 @@
+package kappzzang.jeongsan.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import kappzzang.jeongsan.global.common.enumeration.ErrorType;
+import kappzzang.jeongsan.global.common.enumeration.Status;
+import kappzzang.jeongsan.global.exception.JeongsanException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ExpenseTest {
+
+    private static final Long VALID_TEAM_ID = 1L;
+    private static final Long VALID_MEMBER_ID = 1L;
+    private static final Long INVALID_TEAM_ID = 2L;
+    private static final Long INVALID_MEMBER_ID = 2L;
+
+    @Mock
+    private Team team;
+    @Mock
+    private Member payer;
+    private Expense expense;
+
+    @BeforeEach
+    void setUp() {
+        expense = Expense.builder()
+            .title("TEST_TITLE")
+            .member(payer)
+            .team(team)
+            .category(new Category())
+            .imageUrl("TEST_IMAGE_URL")
+            .paymentTime(LocalDateTime.now())
+            .items(List.of(new Item("TEST_ITEM", 10, 1000)))
+            .build();
+    }
+
+    @DisplayName("진행중인 지출을 송금 대기 상태로 변경할 수 있다")
+    @Test
+    void changeState_OngoingToPending_ShouldSuccess() {
+        //given
+        given(team.getId()).willReturn(VALID_TEAM_ID);
+        given(payer.getId()).willReturn(VALID_MEMBER_ID);
+        //when
+        expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.PENDING);
+        //then
+        assertThat(expense.getStatus()).isEqualTo(Status.PENDING);
+    }
+
+    @DisplayName("송금 대기 중인 지출을 진행중 상태로 변경할 수 있다")
+    @Test
+    void changeState_PendingToOngoing_ShouldSuccess() {
+        //given
+        given(team.getId()).willReturn(VALID_TEAM_ID);
+        given(payer.getId()).willReturn(VALID_MEMBER_ID);
+        expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.PENDING);
+        //when
+        expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.ONGOING);
+        //then
+        assertThat(expense.getStatus()).isEqualTo(Status.ONGOING);
+    }
+
+    @DisplayName("송금 대기 중인 지출을 완료 상태로 변경할 수 있다")
+    @Test
+    void changeState_PendingToComplete_ShouldSuccess() {
+        //given
+        given(team.getId()).willReturn(VALID_TEAM_ID);
+        given(payer.getId()).willReturn(VALID_MEMBER_ID);
+        expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.PENDING);
+        //when
+        expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.COMPLETED);
+        //then
+        assertThat(expense.getStatus()).isEqualTo(Status.COMPLETED);
+    }
+
+    @DisplayName("송금 대기 중인 지출을 다시 송금 대기 상태로 변경하면 예외가 발생한다")
+    @Test
+    void changeState_PendingToPending_throwAlreadyPendingException() {
+        //given
+        given(team.getId()).willReturn(VALID_TEAM_ID);
+        given(payer.getId()).willReturn(VALID_MEMBER_ID);
+        expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.PENDING);
+        //when //then
+        assertThatThrownBy(
+            () -> expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.PENDING))
+            .isInstanceOf(JeongsanException.class)
+            .hasMessage(ErrorType.EXPENSE_ALREADY_PENDING.getMessage());
+    }
+
+    @DisplayName("진행중인 지출을 완료 상태로 변경하면 예외가 발생한다")
+    @Test
+    void changeState_OngoingToComplete_throwExpenseOngoingException() {
+        //when //then
+        assertThatThrownBy(
+            () -> expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.COMPLETED))
+            .isInstanceOf(JeongsanException.class)
+            .hasMessage(ErrorType.EXPENSE_ONGOING.getMessage());
+    }
+
+    @DisplayName("완료된 지출을 다시 완료 상태로 변경하면 예외가 발생한다")
+    @Test
+    void changeState_CompleteToComplete_throwAlreadyCompleteException() {
+        //given
+        given(team.getId()).willReturn(VALID_TEAM_ID);
+        given(payer.getId()).willReturn(VALID_MEMBER_ID);
+        expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.PENDING);
+        expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.COMPLETED);
+        //when //then
+        assertThatThrownBy(
+            () -> expense.changeStatus(VALID_TEAM_ID, VALID_MEMBER_ID, Status.COMPLETED))
+            .isInstanceOf(JeongsanException.class)
+            .hasMessage(ErrorType.EXPENSE_ALREADY_COMPLETED.getMessage());
+    }
+
+    @DisplayName("지출의 팀이 일치하지 않으면 상태 변경 시 예외가 발생한다")
+    @Test
+    void changeState_NotMatchTeam_throwExpenseInvalidTeamException() {
+        //given
+        given(team.getId()).willReturn(VALID_TEAM_ID);
+        //when //then
+        assertThatThrownBy(
+            () -> expense.changeStatus(INVALID_TEAM_ID, VALID_MEMBER_ID, Status.PENDING))
+            .isInstanceOf(JeongsanException.class)
+            .hasMessage(ErrorType.EXPENSE_INVALID_TEAM.getMessage());
+    }
+
+    @DisplayName("지출의 결제자가 일치하지 않으면 상태 변경 시 예외가 발생한다")
+    @Test
+    void changeState_NotMatchPayer_throwExpenseInvalidPayerException() {
+        //given
+        given(team.getId()).willReturn(VALID_TEAM_ID);
+        given(payer.getId()).willReturn(VALID_MEMBER_ID);
+        //when //then
+        assertThatThrownBy(
+            () -> expense.changeStatus(VALID_TEAM_ID, INVALID_MEMBER_ID, Status.PENDING))
+            .isInstanceOf(JeongsanException.class)
+            .hasMessage(ErrorType.EXPENSE_INVALID_PAYER.getMessage());
+    }
+}

--- a/src/test/java/kappzzang/jeongsan/global/client/AwsClientTest.java
+++ b/src/test/java/kappzzang/jeongsan/global/client/AwsClientTest.java
@@ -85,7 +85,7 @@ public class AwsClientTest {
     }
 
     @Test
-    @DisplayName("이미지 업로드 성공 테스트")
+    @DisplayName("유효한 이미지 요청으로 업로드하면 저장된 파일 경로를 반환한다")
     void uploadImage_successfulRequest_returnSavedFilePath() {
         //given
         given(
@@ -101,7 +101,7 @@ public class AwsClientTest {
         then(mockS3Client).should().putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
 
-    @DisplayName("이미지 업로드 실패 테스트(발생 가능한 모든 예외)")
+    @DisplayName("AWS S3 업로드 중 예외가 발생하면 외부 API 에러를 반환한다")
     @ParameterizedTest
     @ValueSource(classes = {NoSuchBucketException.class, NoSuchKeyException.class,
         SdkClientException.class,
@@ -122,7 +122,7 @@ public class AwsClientTest {
     }
 
     @Test
-    @DisplayName("이미지 조회 성공 테스트")
+    @DisplayName("유효한 파일 경로로 조회하면 서명된 URL을 반환한다")
     void getSignedUrl_successfulRequest_returnPresignedUrl() throws MalformedURLException {
         //given
         given(mockS3Presigner.presignGetObject(any(GetObjectPresignRequest.class))).willReturn(
@@ -140,7 +140,7 @@ public class AwsClientTest {
         then(mockS3Presigner).should().presignGetObject(any(GetObjectPresignRequest.class));
     }
 
-    @DisplayName("이미지 조회 실패 테스트(발생 가능한 모든 예외)")
+    @DisplayName("URL 생성 중 예외가 발생하면 각 예외에 맞는 에러를 반환한다")
     @ParameterizedTest
     @MethodSource("exceptionProvider")
     void getSignedUrl_invalidRequest_throwExceptions(Class<? extends Exception> exception,

--- a/src/test/java/kappzzang/jeongsan/global/client/AwsClientTest.java
+++ b/src/test/java/kappzzang/jeongsan/global/client/AwsClientTest.java
@@ -8,7 +8,7 @@ import static org.mockito.BDDMockito.then;
 
 import java.io.InputStream;
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 import java.util.stream.Stream;
 import kappzzang.jeongsan.global.client.aws.AwsClient;
 import kappzzang.jeongsan.global.client.aws.AwsS3Properties;
@@ -127,7 +127,8 @@ public class AwsClientTest {
         //given
         given(mockS3Presigner.presignGetObject(any(GetObjectPresignRequest.class))).willReturn(
             mockPresignedGetObjectRequest);
-        given(mockPresignedGetObjectRequest.url()).willReturn(new URL(TEST_PRESIGNED_URL));
+        given(mockPresignedGetObjectRequest.url()).willReturn(
+            URI.create(TEST_PRESIGNED_URL).toURL());
         given(mockProperties.urlExpirationMillis()).willReturn(TEST_EXPIRES_MILLIS);
 
         //when

--- a/src/test/java/kappzzang/jeongsan/global/client/ClovaApiClientTest.java
+++ b/src/test/java/kappzzang/jeongsan/global/client/ClovaApiClientTest.java
@@ -15,6 +15,7 @@ import kappzzang.jeongsan.global.client.dto.response.GeneralOcrResponse;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
 import kappzzang.jeongsan.global.exception.JeongsanException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -59,6 +60,7 @@ public class ClovaApiClientTest {
         when(clovaOcrProperties.general()).thenReturn(new ClovaOcrProperties.GeneralOcr(TEST_URL));
     }
 
+    @DisplayName("Clova OCR API가 5xx 에러를 반환할 때 재시도 후 외부 API 에러를 반환한다")
     @Test
     void ocrApi_5xxResponse_failsAfterRetries() {
         // Given
@@ -76,6 +78,7 @@ public class ClovaApiClientTest {
         mockRestServiceServer.verify();
     }
 
+    @DisplayName("Clova OCR API가 타임아웃일 때 재시도 후 타임아웃 에러를 반환한다")
     @Test
     void ocrApi_timeout_failsAfterRetries() {
         // Given
@@ -96,6 +99,7 @@ public class ClovaApiClientTest {
         mockRestServiceServer.verify();
     }
 
+    @DisplayName("Clova OCR API가 성공하면 텍스트 인식 결과를 반환한다")
     @Test
     void ocrApi_successfulResponse_returnsGeneralOcrResponse() {
         // Given

--- a/src/test/java/kappzzang/jeongsan/global/client/OpenAiApiClientTest.java
+++ b/src/test/java/kappzzang/jeongsan/global/client/OpenAiApiClientTest.java
@@ -18,6 +18,7 @@ import kappzzang.jeongsan.global.client.openai.OpenAiProperties;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
 import kappzzang.jeongsan.global.exception.JeongsanException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -67,6 +68,7 @@ public class OpenAiApiClientTest {
         when(gptPromptManager.getInstruction()).thenReturn(TEST_INSTRUCTION);
     }
 
+    @DisplayName("OpenAI API가 서버 에러를 반환할 때 최대 재시도 후 외부 API 에러를 반환한다")
     @Test
     void openApi_5xxResponse_failsAfterRetries() {
         // Given
@@ -83,6 +85,7 @@ public class OpenAiApiClientTest {
         mockRestServiceServer.verify();
     }
 
+    @DisplayName("OpenAI API가 응답하지 않을 때 최대 재시도 후 타임아웃 에러를 반환한다")
     @Test
     void openApi_timeout_failsAfterRetries() {
         // Given
@@ -102,6 +105,7 @@ public class OpenAiApiClientTest {
         mockRestServiceServer.verify();
     }
 
+    @DisplayName("OpenAI API가 성공하면 텍스트 분석 결과를 반환한다")
     @Test
     void openApi_successfulResponse_returnChatGptResponse() {
         // Given

--- a/src/test/java/kappzzang/jeongsan/repository/ExpenseRepositoryTest.java
+++ b/src/test/java/kappzzang/jeongsan/repository/ExpenseRepositoryTest.java
@@ -12,8 +12,11 @@ import kappzzang.jeongsan.domain.Member;
 import kappzzang.jeongsan.domain.PersonalExpense;
 import kappzzang.jeongsan.domain.Team;
 import kappzzang.jeongsan.dto.ItemDetail;
+import kappzzang.jeongsan.global.common.enumeration.ErrorType;
+import kappzzang.jeongsan.global.exception.JeongsanException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -34,7 +37,10 @@ public class ExpenseRepositoryTest {
     private TestDataUtil testDataUtil;
 
     private Expense expense;
+    private List<Expense> expenses;
     private List<Member> members;
+    private List<Long> expenseIds;
+    private Long payerId;
 
     @BeforeEach
     void setUp() {
@@ -43,6 +49,7 @@ public class ExpenseRepositoryTest {
         Member memberA = testDataUtil.createAndPersistMember("TEST_USER_A", kakaoPayInfo);
         Member memberB = testDataUtil.createAndPersistMember("TEST_USER_B", kakaoPayInfo);
         Member memberC = testDataUtil.createAndPersistMember("TEST_USER_C", kakaoPayInfo);
+        Member payer = testDataUtil.createAndPersistMember("TEST_PAYER", kakaoPayInfo);
         members = List.of(memberA, memberB, memberC);
 
         Team team = testDataUtil.createAndPersistTeam();
@@ -51,6 +58,7 @@ public class ExpenseRepositoryTest {
         Item itemB = testDataUtil.createAndPersistItem("TEST_ITEM_B", 5, 3000);
         Item itemC = testDataUtil.createAndPersistItem("TEST_ITEM_C", 15, 4000);
         Item itemD = testDataUtil.createAndPersistItem("TEST_ITEM_D", 3, 1000);
+        Item itemE = testDataUtil.createAndPersistItem("TEST_ITEM_E", 1, 1000);
 
         PersonalExpense personalExpenseA = testDataUtil.createAndPersistPersonalExpense(memberA, 5,
             itemA, 0);
@@ -66,6 +74,16 @@ public class ExpenseRepositoryTest {
         Category category = testDataUtil.createAndPersistCategory();
 
         expense = testDataUtil.createAndPersistExpense(team, memberA, category, items);
+
+        Expense expense1 = testDataUtil.createAndPersistExpense(team, payer, category,
+            List.of(itemE));
+        Expense expense2 = testDataUtil.createAndPersistExpense(team, payer, category,
+            List.of(itemE));
+        Expense expense3 = testDataUtil.createAndPersistExpense(team, payer, category,
+            List.of(itemE));
+        expenses = List.of(expense1, expense2, expense3);
+        payerId = payer.getId();
+        expenseIds = List.of(expense1.getId(), expense2.getId(), expense3.getId());
     }
 
     @MethodSource("PersonalExpenseCaseProvider")
@@ -92,6 +110,44 @@ public class ExpenseRepositoryTest {
                 }
             });
     }
+
+
+    @DisplayName("지출 Id 리스트로 지출과 연관정보를 함께 조회할 수 있다")
+    @Test
+    void findAllByIdWithDetails_ValidIds_ReturnsExpenses() {
+        //when
+        List<Expense> actual = expenseRepository.findAllByIdWithDetails(expenseIds);
+
+        //then
+        assertThat(actual).hasSize(expenses.size())
+            .allMatch(e -> e.getPayer().getId().equals(payerId));
+    }
+
+    @DisplayName("존재하지 않는 지출 Id로 조회시 빈 리스트를 반환한다")
+    @Test
+    void findAllByIdWithDetails_NonExistentIds_ShouldReturnEmptyList() {
+        //given
+        List<Long> invalidIds = List.of(100L, 200L, 300L);
+
+        //when
+        List<Expense> actual = expenseRepository.findAllByIdWithDetails(invalidIds);
+
+        //then
+        assertThat(actual).hasSize(0);
+    }
+
+    @DisplayName("지출 ID로 아이템 목록이 포함된 지출을 조회한다")
+    @Test
+    void findExpenseByIdWithItem_ValidId_ReturnsExpense() {
+        //when
+        Expense actual = expenseRepository.findExpenseByIdWithItem(expense.getId())
+            .orElseThrow(() -> new JeongsanException(ErrorType.EXPENSE_NOT_FOUND));
+
+        //then
+        assertThat(actual.getId()).isEqualTo(expense.getId());
+        assertThat(actual.getItems()).hasSize(TEST_ITEM_QUANTITY);
+    }
+
 
     static Stream<Arguments> PersonalExpenseCaseProvider() {
         return Stream.of(

--- a/src/test/java/kappzzang/jeongsan/repository/PersonalExpenseRepositoryTest.java
+++ b/src/test/java/kappzzang/jeongsan/repository/PersonalExpenseRepositoryTest.java
@@ -25,6 +25,7 @@ class PersonalExpenseRepositoryTest {
     Member member1, member2;
     Expense expense1, expense2;
     PersonalExpense personalExpense1, personalExpense2, personalExpense3;
+    private List<Long> itemIds;
     @Autowired
     private PersonalExpenseRepository personalExpenseRepository;
     @Autowired
@@ -39,6 +40,7 @@ class PersonalExpenseRepositoryTest {
         Item item2 = testDataUtil.createAndPersistItem("item2", 10, 2000);
         List<Item> items1 = List.of(item1);
         List<Item> items2 = List.of(item2);
+        itemIds = List.of(item1.getId(), item2.getId());
         member1 = testDataUtil.createAndPersistMember("member1", kakaoPayInfo);
         member2 = testDataUtil.createAndPersistMember("member2", kakaoPayInfo);
         expense1 = testDataUtil.createAndPersistExpense(team, member1, category, items1);
@@ -63,4 +65,22 @@ class PersonalExpenseRepositoryTest {
         assertThat(results).containsExactlyInAnyOrder(personalExpense1, personalExpense2,
             personalExpense3);
     }
+
+    @DisplayName("아이템 Id 목록으로 회원과 아이템이 포함된 개인 지출 목록을 조회한다")
+    @Test
+    void findAllByItemIds_WithItemIds_ReturnPersonalExpenses() {
+        //when
+        List<PersonalExpense> actual = personalExpenseRepository.findAllByItemIds(itemIds);
+
+        //then
+        assertThat(actual)
+            .hasSize(3)
+            .allSatisfy(personalExpense -> {
+                assertThat(personalExpense.getId()).isNotNull();
+                assertThat(personalExpense.getMember()).isNotNull();
+                assertThat(personalExpense.getItem()).isNotNull();
+                assertThat(itemIds).contains(personalExpense.getItem().getId());
+            });
+    }
+
 }

--- a/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
@@ -92,7 +92,7 @@ public class ExpenseServiceTest {
     }
 
     @Test
-    @DisplayName("지출 상태 내역을 조회할 때, 존재하지 않는 지출에 대해 요청 시, NotFoundException을 발생 시킨다.")
+    @DisplayName("지출 상태 내역을 조회할 때, 존재하지 않는 지출에 대해 요청 시, NotFoundException을 발생 시킨다")
     void getPersonalExpenseDetail_NoSuchExpense_ThrowNotFoundException() {
         //given
         given(expenseRepository.findById(TEST_EXPENSE_ID)).willReturn(Optional.empty());

--- a/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/ExpenseServiceTest.java
@@ -19,11 +19,9 @@ import kappzzang.jeongsan.domain.Expense;
 import kappzzang.jeongsan.domain.Item;
 import kappzzang.jeongsan.domain.Member;
 import kappzzang.jeongsan.domain.Team;
-import kappzzang.jeongsan.dto.ItemDetail;
 import kappzzang.jeongsan.dto.request.ChangeExpensesStateRequest;
 import kappzzang.jeongsan.dto.request.ChangeExpensesStateRequest.ExpenseId;
 import kappzzang.jeongsan.dto.response.ExpenseResponse;
-import kappzzang.jeongsan.dto.response.PersonalExpenseDetailResponse;
 import kappzzang.jeongsan.global.common.enumeration.ErrorType;
 import kappzzang.jeongsan.global.common.enumeration.Status;
 import kappzzang.jeongsan.global.exception.JeongsanException;
@@ -67,9 +65,6 @@ public class ExpenseServiceTest {
     private TeamRepository teamRepository;
 
     @Mock
-    private ImageStorageService imageStorageService;
-
-    @Mock
     private ExpenseRepository expenseRepository;
 
     @Mock
@@ -97,42 +92,10 @@ public class ExpenseServiceTest {
     }
 
     @Test
-    @DisplayName("개인 지출 목록 조회 성공 테스트")
-    void testGetPersonalExpenseDetailResponseSuccess() {
+    @DisplayName("지출 상태 내역을 조회할 때, 존재하지 않는 지출에 대해 요청 시, NotFoundException을 발생 시킨다.")
+    void getPersonalExpenseDetail_NoSuchExpense_ThrowNotFoundException() {
         //given
-        ItemDetail itemDetailA = new ItemDetail(1L, "TEST_ITEM_A", 10, 1000, 10);
-        ItemDetail itemDetailB = new ItemDetail(2L, "TEST_ITEM_B", 5, 5000, 0);
-        ItemDetail itemDetailC = new ItemDetail(3L, "TEST_ITEM_C", 3, 2000, 5);
-        List<ItemDetail> itemDetails = List.of(itemDetailA, itemDetailB, itemDetailC);
-        PersonalExpenseDetailResponse expected = new PersonalExpenseDetailResponse(
-            expense.getTitle(), TEST_PRE_SIGNED_URL, itemDetails);
-
-        given(expenseRepository.findById(TEST_EXPENSE_ID)).willReturn(
-            Optional.ofNullable(expense));
-        given(expenseRepository.findItemDetailsByExpenseIdAndMemberId(TEST_EXPENSE_ID,
-            TEST_MEMBER_ID)).willReturn(
-            itemDetails);
-        given(imageStorageService.getImageUrl(TEST_IMAGE_URL)).willReturn(TEST_PRE_SIGNED_URL);
-
-        //when
-        PersonalExpenseDetailResponse actual = expenseService.getPersonalExpenseDetailResponse(
-            TEST_EXPENSE_ID,
-            TEST_MEMBER_ID);
-
-        //then
-        assertThat(actual).isEqualTo(expected);
-        then(expenseRepository).should().findById(TEST_EXPENSE_ID);
-        then(expenseRepository).should().findItemDetailsByExpenseIdAndMemberId(TEST_EXPENSE_ID,
-            TEST_MEMBER_ID);
-        then(imageStorageService).should().getImageUrl(TEST_IMAGE_URL);
-    }
-
-    @Test
-    @DisplayName("개인 지출 목록 조회 실패(존재하지 않는 지출 ID)")
-    void testGetPersonalExpenseDetailResponseFailWithNotFoundExpense() {
-        //given
-        given(expenseRepository.findById(TEST_EXPENSE_ID)).willThrow(new JeongsanException(
-            ErrorType.EXPENSE_NOT_FOUND));
+        given(expenseRepository.findById(TEST_EXPENSE_ID)).willReturn(Optional.empty());
 
         //when //then
         assertThatThrownBy(

--- a/src/test/java/kappzzang/jeongsan/service/ImageStorageServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/ImageStorageServiceTest.java
@@ -39,7 +39,7 @@ public class ImageStorageServiceTest {
     private ImageStorageService imageStorageService;
 
     @Test
-    @DisplayName("이미지 저장 성공 테스트")
+    @DisplayName("유효한 이미지를 저장 시도 시, 저장 경로를 반환한다.")
     void saveImage_validData_returnSavedFileUrl() {
         //given
         Image imageForSuccess = new Image(TEST_IMAGE_FORMAT, null, TEST_IMAGE_DATA,
@@ -55,7 +55,7 @@ public class ImageStorageServiceTest {
     }
 
     @ParameterizedTest
-    @DisplayName("이미지 저장 성공 실패 테스트(잘못된 입력)")
+    @DisplayName("잘못된 형식의 이미지를 저장 시도 시, InvalidInputException을 발생 시킨다.")
     @ValueSource(strings = {TEST_IMAGE_DATA_INVALID, TEST_IMAGE_DATA_BLANK})
     void saveImage_invalidDataList_throwException(String data) {
         //given

--- a/src/test/java/kappzzang/jeongsan/service/ImageStorageServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/ImageStorageServiceTest.java
@@ -55,7 +55,7 @@ public class ImageStorageServiceTest {
     }
 
     @ParameterizedTest
-    @DisplayName("잘못된 형식의 이미지를 저장 시도 시, InvalidInputException을 발생 시킨다.")
+    @DisplayName("잘못된 형식의 이미지를 저장 시도 시, InvalidInputException을 발생 시킨다")
     @ValueSource(strings = {TEST_IMAGE_DATA_INVALID, TEST_IMAGE_DATA_BLANK})
     void saveImage_invalidDataList_throwException(String data) {
         //given


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- 리펙토링
  - `개인 지출 목록 조회 성공 테스트` : 제거
  - `개인 지출 목록 조회 실패(존재하지 않는 지출 ID)` : mocking 데이터 리턴값을 Optional 데이터로 변경
  - `saveImage_invalidDataList_throwException` : DisplayName 수정
  - 외부API 테스트 DisplayName 수정
- 도메인 테스트 추가
  - Expense : `changeStatus`
- 리포지토리 테스트 추가
  - `findAllByItemIds`
  - `findAllByIdWithDetails` 
  - `findExpenseByIdWithItem`

### 🔍 참고 사항
- 11/11 회의 의견 반영하여 테스트 코드 수정 및 추가 하였습니다.

### ⚠️ 의논 필요
- X
### 🐞현재 버그
- X

### #️⃣ 연관 이슈(Git Close)
close #171 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
