### PR TITLE
Fix/issue#166: 모든 team_member 정보를 불러올 수 있도록 쿼리 수정

### DIFF
--- a/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
@@ -2,17 +2,17 @@ package kappzzang.jeongsan.repository;
 
 import java.util.List;
 import kappzzang.jeongsan.domain.Team;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
 
-    @EntityGraph(attributePaths = {"teamMemberList.member"})
-    @Query("SELECT t FROM Team t " +
-        "JOIN t.teamMemberList tm " +
-        "WHERE tm.member.id = :memberId " +
-        "AND t.isClosed = :isClosed")
+    @Query("SELECT DISTINCT t FROM Team t " +
+       "JOIN t.teamMemberList tm " +
+       "JOIN FETCH t.teamMemberList allMembers " +
+       "JOIN FETCH allMembers.member " +
+       "WHERE tm.member.id = :memberId " +
+       "AND t.isClosed = :isClosed")
     List<Team> findByIsClosed(@Param("memberId") Long memberId, @Param("isClosed") Boolean isClosed);
 }

--- a/src/main/java/kappzzang/jeongsan/service/TeamService.java
+++ b/src/main/java/kappzzang/jeongsan/service/TeamService.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import kappzzang.jeongsan.domain.Member;
 import kappzzang.jeongsan.domain.PersonalExpense;
 import kappzzang.jeongsan.domain.Team;
+import kappzzang.jeongsan.domain.TeamMember;
 import kappzzang.jeongsan.dto.request.CreateTeamRequest;
 import kappzzang.jeongsan.dto.request.TransferTargetRequest;
 import kappzzang.jeongsan.dto.response.CreateTeamResponse;
@@ -22,9 +23,11 @@ import kappzzang.jeongsan.repository.PersonalExpenseRepository;
 import kappzzang.jeongsan.repository.TeamMemberRepository;
 import kappzzang.jeongsan.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TeamService {
@@ -36,7 +39,26 @@ public class TeamService {
 
     @Transactional(readOnly = true)
     public List<TeamResponse> getTeamsByIsClosed(Boolean isClosed, Long memberId) {
-        return teamRepository.findByIsClosed(memberId, isClosed)
+        List<Team> teams = teamRepository.findByIsClosed(memberId, isClosed);
+
+        for (Team team : teams) {
+            log.info("Team ID: {}, Name: {}, Subject: {}, isClosed: {}",
+                        team.getId(), team.getName(), team.getSubject(), team.getIsClosed());
+
+            for (TeamMember teamMember : team.getTeamMemberList()) {
+                log.info("  TeamMember ID: {}, isOwner: {}, isInviteAccepted: {}",
+                            teamMember.getId(), teamMember.getIsOwner(), teamMember.getIsInviteAccepted());
+
+                Member member = teamMember.getMember();
+                log.info("    Member ID: {}, KakaoId: {}, Nickname: {}",
+                            member.getId(), member.getKakaoId(), member.getNickname());
+            }
+        }
+
+        log.info("getTeamsByIsClosed teams: {}", teams);
+        log.info("getTeamsByIsClosed teamMembers: {}", teams);
+
+        return teams
             .stream()
             .map(TeamResponse::from)
             .toList();

--- a/src/main/java/kappzzang/jeongsan/service/TeamService.java
+++ b/src/main/java/kappzzang/jeongsan/service/TeamService.java
@@ -8,7 +8,6 @@ import java.util.stream.Collectors;
 import kappzzang.jeongsan.domain.Member;
 import kappzzang.jeongsan.domain.PersonalExpense;
 import kappzzang.jeongsan.domain.Team;
-import kappzzang.jeongsan.domain.TeamMember;
 import kappzzang.jeongsan.dto.request.CreateTeamRequest;
 import kappzzang.jeongsan.dto.request.TransferTargetRequest;
 import kappzzang.jeongsan.dto.response.CreateTeamResponse;
@@ -23,11 +22,9 @@ import kappzzang.jeongsan.repository.PersonalExpenseRepository;
 import kappzzang.jeongsan.repository.TeamMemberRepository;
 import kappzzang.jeongsan.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TeamService {
@@ -40,24 +37,6 @@ public class TeamService {
     @Transactional(readOnly = true)
     public List<TeamResponse> getTeamsByIsClosed(Boolean isClosed, Long memberId) {
         List<Team> teams = teamRepository.findByIsClosed(memberId, isClosed);
-
-        for (Team team : teams) {
-            log.info("Team ID: {}, Name: {}, Subject: {}, isClosed: {}",
-                        team.getId(), team.getName(), team.getSubject(), team.getIsClosed());
-
-            for (TeamMember teamMember : team.getTeamMemberList()) {
-                log.info("  TeamMember ID: {}, isOwner: {}, isInviteAccepted: {}",
-                            teamMember.getId(), teamMember.getIsOwner(), teamMember.getIsInviteAccepted());
-
-                Member member = teamMember.getMember();
-                log.info("    Member ID: {}, KakaoId: {}, Nickname: {}",
-                            member.getId(), member.getKakaoId(), member.getNickname());
-            }
-        }
-
-        log.info("getTeamsByIsClosed teams: {}", teams);
-        log.info("getTeamsByIsClosed teamMembers: {}", teams);
-
         return teams
             .stream()
             .map(TeamResponse::from)
@@ -71,7 +50,7 @@ public class TeamService {
         Team team = teamRepository.findById(id)
             .orElseThrow(() -> new JeongsanException(ErrorType.TEAM_NOT_FOUND));
 
-        if(!team.isMember(member)) {
+        if (!team.isMember(member)) {
             throw new JeongsanException(ErrorType.USER_NOT_FOUND);
         }
 


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- JPQL 쿼리 수정

### 🔍 버그 원인
- JPQL을 통한 데이터 호출 시 member id 조건이 있는데, 이로 인해 team에 속하는 모든 member 데이터를 불러올 수 없었습니다
- 이에 따라 teamMemberList에서 isOwner인 member 객체를 찾을 수 없어 예외를 발생시켰습니다.

### 🔍 참고 사항
- 테스트 서버에 직접 push로 실제 작동 확인했습니다

### 🐞현재 버그
- X

### #️⃣ 연관 이슈(Git Close)
close #166 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
