### PR TITLE
Fix/issue#169: Access 토큰 재발급 과정에서 인증 과정 생략

### DIFF
--- a/src/main/java/kappzzang/jeongsan/controller/MemberController.java
+++ b/src/main/java/kappzzang/jeongsan/controller/MemberController.java
@@ -49,9 +49,9 @@ public class MemberController implements MemberControllerInterface {
     @Override
     @PostMapping("/token/refresh")
     public ResponseEntity<JeongsanApiResponse<RefreshResponse>> refresh(
-        @AuthenticationPrincipal Long memberId, @Valid @RequestBody RefreshRequest refreshRequest) {
+        @Valid @RequestBody RefreshRequest refreshRequest) {
         return JeongsanApiResponse.success(SuccessType.ACCESS_TOKEN_REISSUED,
-            memberService.refresh(memberId, refreshRequest));
+            memberService.refresh(refreshRequest));
     }
 
     @Override

--- a/src/main/java/kappzzang/jeongsan/controller/docs/MemberControllerInterface.java
+++ b/src/main/java/kappzzang/jeongsan/controller/docs/MemberControllerInterface.java
@@ -43,8 +43,7 @@ public interface MemberControllerInterface {
     })
     @ApiResponse(responseCode = "200", description = "액세스 토큰 재발급 성공")
     @ApiErrorTypeExample({ErrorType.USER_NOT_FOUND, ErrorType.REFRESH_TOKEN_INVALID})
-    ResponseEntity<JeongsanApiResponse<RefreshResponse>> refresh(Long memberId,
-        RefreshRequest refreshRequest);
+    ResponseEntity<JeongsanApiResponse<RefreshResponse>> refresh(RefreshRequest refreshRequest);
 
     @Operation(summary = "모임 초대 수락 API", description = "모임 초대 링크를 받은 사용자가 모임 참여를 수락하여 모임에 참여하도록 하는 API")
     @ApiResponse(responseCode = "204", description = "모임 초대 수락, 모임 참여 성공")

--- a/src/main/java/kappzzang/jeongsan/global/util/JwtUtil.java
+++ b/src/main/java/kappzzang/jeongsan/global/util/JwtUtil.java
@@ -77,9 +77,10 @@ public class JwtUtil {
             .compact();
     }
 
-    public String createRefreshToken() {
+    public String createRefreshToken(Long id) {
         LocalDateTime now = LocalDateTime.now();
         return Jwts.builder()
+            .subject(Long.toString(id))
             .claim("iat", createIssueAt(now))
             .claim("exp", createExpiration(now, jwtProperties.refreshExpirationTime()))
             .signWith(secretKey)

--- a/src/main/java/kappzzang/jeongsan/service/MemberService.java
+++ b/src/main/java/kappzzang/jeongsan/service/MemberService.java
@@ -55,7 +55,7 @@ public class MemberService {
 
     private LoginResponse createToken(Member member) {
         String accessToken = jwtUtil.createAccessToken(member.getId());
-        String refreshToken = jwtUtil.createRefreshToken();
+        String refreshToken = jwtUtil.createRefreshToken(member.getId());
         member.updateRefreshToken(refreshToken);
         memberRepository.save(member);
 

--- a/src/main/java/kappzzang/jeongsan/service/MemberService.java
+++ b/src/main/java/kappzzang/jeongsan/service/MemberService.java
@@ -63,10 +63,11 @@ public class MemberService {
     }
 
     @Transactional
-    public RefreshResponse refresh(Long memberId, RefreshRequest refreshRequest) {
+    public RefreshResponse refresh(RefreshRequest refreshRequest) {
+        String refreshToken = refreshRequest.refreshToken();
+        Long memberId = jwtUtil.getMemberId(refreshToken);
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new JeongsanException(USER_NOT_FOUND));
-        String refreshToken = refreshRequest.refreshToken();
         if (!refreshToken.equals(member.getRefreshToken())
             || !jwtUtil.validateRefreshToken(refreshToken)) {
             throw new JeongsanException(REFRESH_TOKEN_INVALID);

--- a/src/test/java/kappzzang/jeongsan/service/MemberServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/MemberServiceTest.java
@@ -69,7 +69,7 @@ public class MemberServiceTest {
         given(memberRepository.findByEmail(anyString())).willReturn(
             Optional.of(createMember(null)));
         given(jwtUtil.createAccessToken(any())).willReturn(TEST_ACCESS_TOKEN);
-        given(jwtUtil.createRefreshToken()).willReturn(TEST_REFRESH_TOKEN);
+        given(jwtUtil.createRefreshToken(any())).willReturn(TEST_REFRESH_TOKEN);
 
         // when
         LoginResponse loginResponse = memberService.login(new LoginRequest(anyString()));
@@ -105,7 +105,7 @@ public class MemberServiceTest {
         given(memberRepository.findByEmail(anyString())).willReturn(Optional.empty());
         given(memberRepository.save(any(Member.class))).willReturn(createMember(null));
         given(jwtUtil.createAccessToken(any())).willReturn(TEST_ACCESS_TOKEN);
-        given(jwtUtil.createRefreshToken()).willReturn(TEST_REFRESH_TOKEN);
+        given(jwtUtil.createRefreshToken(any())).willReturn(TEST_REFRESH_TOKEN);
 
         // when
         LoginResponse loginResponse = memberService.register(registerRequest);

--- a/src/test/java/kappzzang/jeongsan/service/MemberServiceTest.java
+++ b/src/test/java/kappzzang/jeongsan/service/MemberServiceTest.java
@@ -125,7 +125,7 @@ public class MemberServiceTest {
         given(memberRepository.findById(anyLong())).willReturn(Optional.of(createMember(null)));
 
         // when & then
-        assertThatThrownBy(() -> memberService.refresh(anyLong(), refreshRequest))
+        assertThatThrownBy(() -> memberService.refresh(refreshRequest))
             .isInstanceOf(JeongsanException.class)
             .hasFieldOrPropertyWithValue("errorType", ErrorType.REFRESH_TOKEN_INVALID);
     }
@@ -139,7 +139,7 @@ public class MemberServiceTest {
         given(jwtUtil.validateRefreshToken(TEST_REFRESH_TOKEN)).willReturn(false);
 
         // when & then
-        assertThatThrownBy(() -> memberService.refresh(anyLong(), refreshRequest))
+        assertThatThrownBy(() -> memberService.refresh(refreshRequest))
             .isInstanceOf(JeongsanException.class)
             .hasFieldOrPropertyWithValue("errorType", ErrorType.REFRESH_TOKEN_INVALID);
     }
@@ -154,7 +154,7 @@ public class MemberServiceTest {
         given(jwtUtil.createAccessToken(anyLong())).willReturn(TEST_ACCESS_TOKEN);
 
         // when
-        RefreshResponse refreshResponse = memberService.refresh(anyLong(), refreshRequest);
+        RefreshResponse refreshResponse = memberService.refresh(refreshRequest);
 
         // then
         assertThat(refreshResponse.tokenType()).isEqualTo(BEARER);


### PR DESCRIPTION
## PR
### ✨ 작업 내용
- Access 토큰 재발급 과정에서 인증 과정 생략

### 🔍 참고 사항
- 만료된 Access 토큰에서 멤버 정보를 가져올 수 없기에 인증 과정을 삭제하였습니다.
- Refresh 토큰에 멤버 정보를 추가하였습니다.
- 접근 허용 경로에 `/api/members/token/refresh`도 추가할 필요가 있습니다.

### ⚠️ 의논 필요
X

### 🐞현재 버그
X

### #️⃣ 연관 이슈(Git Close)
close #169 

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
