### PR TITLE
Fix/issue#190: 초대를 수락하지 않은 모임도 조회할 수 있는 문제 수정

### DIFF
--- a/src/main/java/kappzzang/jeongsan/domain/Team.java
+++ b/src/main/java/kappzzang/jeongsan/domain/Team.java
@@ -94,7 +94,7 @@ public class Team extends BaseEntity {
     public Boolean isMember(Member member) {
         return this.teamMemberList.stream()
             .anyMatch(teamMember -> teamMember.getMember()
-                .equals(member));
+                .equals(member) && teamMember.getIsInviteAccepted());
     }
 
     @Override

--- a/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
+++ b/src/main/java/kappzzang/jeongsan/repository/TeamRepository.java
@@ -9,10 +9,11 @@ import org.springframework.data.repository.query.Param;
 public interface TeamRepository extends JpaRepository<Team, Long> {
 
     @Query("SELECT DISTINCT t FROM Team t " +
-       "JOIN t.teamMemberList tm " +
-       "JOIN FETCH t.teamMemberList allMembers " +
-       "JOIN FETCH allMembers.member " +
-       "WHERE tm.member.id = :memberId " +
-       "AND t.isClosed = :isClosed")
+        "JOIN t.teamMemberList tm " +
+        "JOIN FETCH t.teamMemberList allMembers " +
+        "JOIN FETCH allMembers.member " +
+        "WHERE tm.member.id = :memberId " +
+        "AND tm.isInviteAccepted = true " +
+        "AND t.isClosed = :isClosed")
     List<Team> findByIsClosed(@Param("memberId") Long memberId, @Param("isClosed") Boolean isClosed);
 }

--- a/src/test/java/kappzzang/jeongsan/domain/TeamTest.java
+++ b/src/test/java/kappzzang/jeongsan/domain/TeamTest.java
@@ -119,10 +119,43 @@ class TeamTest {
         ReflectionTestUtils.setField(member, "id", 2L);
         ReflectionTestUtils.setField(nonMember, "id", 3L);
 
+        team.getTeamMemberList().forEach(teamMember -> {
+            if (teamMember.getMember().equals(member)) {
+                ReflectionTestUtils.setField(teamMember, "isInviteAccepted", true);
+            }
+        });
+
         // when & then
         assertThat(team.isMember(owner)).isTrue();
         assertThat(team.isMember(member)).isTrue();
         assertThat(team.isMember(nonMember)).isFalse();
+    }
+
+    @Test
+    @DisplayName("팀에 특정 멤버가 초대를 수락하지 않았을 때 예외 발생")
+    void isMemberNotAccepted() {
+        // given
+        Member owner = createOwnerMember();
+        Member member = createMember("memberKakaoId");
+        Member notAcceptedMember = createMember("notAcceptedMemberKakaoId");
+        Team team = Team.createTeam(owner, "test team", "🎇", List.of(member));
+
+        ReflectionTestUtils.setField(owner, "id", 1L);
+        ReflectionTestUtils.setField(member, "id", 2L);
+        ReflectionTestUtils.setField(notAcceptedMember, "id", 3L);
+
+        team.getTeamMemberList().forEach(teamMember -> {
+            if (teamMember.getMember().equals(notAcceptedMember)) {
+                ReflectionTestUtils.setField(teamMember, "isInviteAccepted", false);
+            } else {
+                ReflectionTestUtils.setField(teamMember, "isInviteAccepted", true);
+            }
+        });
+
+        // when & then
+        assertThat(team.isMember(owner)).isTrue();
+        assertThat(team.isMember(member)).isTrue();
+        assertThat(team.isMember(notAcceptedMember)).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## PR
### 🔍 원인
- `TeamMember.isInviteAccepted`를 확인하지 않은 문제

### ✨ 작업 내용
- 모임 단일 조회에서 사용되는 `Team.isMember()` 메서드에서 `isInviteAccepted` 확인 추가
- 모임 목록 조회 JPQL에 조건 추가

### ⚠️ 의논 필요
- 팀원들의 의견을 듣고 싶거나, 의논이 필요한 사항이 있다면 작성

### 🐞현재 버그
- 현재 버전에 버그가 있다면 작성

### #️⃣ 연관 이슈(Git Close)
close #190

___
### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
